### PR TITLE
Update Argo handler to make relative path root properly accessible to…

### DIFF
--- a/aodndata/argo/handler.py
+++ b/aodndata/argo/handler.py
@@ -7,7 +7,9 @@ class ArgoHandler(HandlerBase):
     def __init__(self, *args, **kwargs):
         super(ArgoHandler, self).__init__(*args, **kwargs)
         self.allowed_extensions = ['.rsync_manifest']
-        self.relative_path_root = os.path.join(self._config.pipeline_config['global']['wip_dir'], 'Argo/dac')
+
+        relative_path_root = os.path.join(self._config.pipeline_config['global']['wip_dir'], 'Argo/dac')
+        self.resolve_params = {'relative_path_root': relative_path_root}
 
     def dest_path(self, filepath):
         """The dest_path has already been added to the PipelineFile by the MapManifestResolveRunner, so simply validate
@@ -16,5 +18,5 @@ class ArgoHandler(HandlerBase):
         :param filepath: filepath for which to retrieve the destination path from the corresponding PipelineFile
         :return: string containing the dest_path attribute of the PipelineFile corresponding with filepath
         """
-        rel_path = os.path.relpath(filepath, self.relative_path_root)
+        rel_path = os.path.relpath(filepath, self.resolve_params['relative_path_root'])
         return os.path.join('IMOS/Argo/dac', rel_path)


### PR DESCRIPTION
… the resolve runner

This *should* correct the issue with Argo's relative path issue with manifests.

This "relative_path_root" attribute of the handler was a relic from an earlier version, before "resolve_params" existed, so this should set it in a consistent way for both the resolve runner AND the dest_path function.