### PR TITLE
Refactor to use more standard dest_path setting. Remove some redundan…

### DIFF
--- a/aodndata/anfog/classifiers.py
+++ b/aodndata/anfog/classifiers.py
@@ -66,13 +66,12 @@ class AnfogFileClassifier(FileClassifier):
         IMOS/ANFOG/platform/deployment_code/
         in a REALTIME path like :
         IMOS/ANFOG/REALTIME/platform/deployment_code/ """
-        hierarchy = path.split('/')
-        assert len(hierarchy) == 4, "Path should have 4 parts "
-        rt_path = []
-        rt_path.extend([hierarchy[0], hierarchy[1]])
-        rt_path.append('REALTIME')
-        rt_path.extend([hierarchy[2], hierarchy[3]])
+        try:
+            org, facility, platform, deployment_code = path.split('/')
+        except ValueError:
+            raise ValueError("path '{path}' must have 4 parts".format(path=path))
 
+        rt_path = [org, facility, 'REALTIME', platform, deployment_code]
         return cls._make_path(rt_path)
 
     @classmethod

--- a/aodndata/anfog/classifiers.py
+++ b/aodndata/anfog/classifiers.py
@@ -76,23 +76,24 @@ class AnfogFileClassifier(FileClassifier):
         return cls._make_path(rt_path)
 
     @classmethod
-    def dest_path(cls, src_file):
+    def get_destination(cls, src_path):
+        name = os.path.basename(src_path)
         dir_list = []
-        fields = cls._get_file_name_fields(src_file.name)
-        platform = cls.get_platform(src_file.name)
-        deployment_code = cls.get_deployment_code(src_file.src_path)
+        fields = cls._get_file_name_fields(name)
+        platform = cls.get_platform(name)
+        deployment_code = cls.get_deployment_code(src_path)
 
-        if re.match(cls.NRL_REGEX, src_file.name):
+        if re.match(cls.NRL_REGEX, name):
             project = cls.NRL_BASE
             dir_list.append(project)
-        elif re.match(cls.DSTG_REGEX, src_file.name):
+        elif re.match(cls.DSTG_REGEX, name):
             project = cls.DSTG_BASE
             dir_list.append(project)
         else:  # IMOS ANFOG RT or DM
             project = fields[0]
             facility = fields[1]
             dir_list.extend([project, facility])
-            if re.match(cls.ANFOG_RT_REGEX, src_file.name):
+            if re.match(cls.ANFOG_RT_REGEX, name):
                 data_type = 'REALTIME'
                 dir_list.append(data_type)
 

--- a/aodndata/anfog/handlers.py
+++ b/aodndata/anfog/handlers.py
@@ -198,22 +198,22 @@ class AnfogHandler(HandlerBase):
         for filename in previous_file_list.iteritems():
             if filename.endswith('.nc'):
                 previous_file = PipelineFile(filename)
-                self.file_collection.add(previous_file)
                 previous_file.dest_path = os.path.join(destination, previous_file.name)
                 previous_file.publish_type = PipelineFilePublishType.DELETE_UNHARVEST
+                self.file_collection.add(previous_file)
             else:
                 if mode == 'RT' and re.match(AnfogFileClassifier.RT_PNG_TRANSECT_REGEX, filename):
                     # delete plot of transect results
                     previous_file = PipelineFile(filename)
-                    self.file_collection.add(previous_file)
                     previous_file.dest_path = os.path.join(destination, previous_file.name)
                     previous_file.publish_type = PipelineFilePublishType.DELETE_ONLY
+                    self.file_collection.add(previous_file)
                 elif mode == 'DM' and mission_status == 'delayed_mode':
                     # clear all RT files
                     previous_file = PipelineFile(filename)
-                    self.file_collection.add(previous_file)
                     previous_file.dest_path = os.path.join(destination, previous_file.name)
                     previous_file.publish_type = PipelineFilePublishType.DELETE_ONLY
+                    self.file_collection.add(previous_file)
 
     def get_data_mode(self):
         """Based on ZIP content, define the data mode - DM or RT
@@ -248,9 +248,9 @@ class AnfogHandler(HandlerBase):
         # jpg,kml and QC_Report.pdf -> S3
 
         # construct collection of files to archive
-        archive_collection = PipelineFileCollection()
         raw = self.file_collection.filter_by_attribute_regex('name', '.*rawfiles.zip$')
         fv00 = self.file_collection.filter_by_attribute_regex('name', AnfogFileClassifier.FV00_REGEX)
+        archive_collection = PipelineFileCollection()
         archive_collection.update(raw)
         archive_collection.update(fv00)
 

--- a/test_aodndata/anfog/test_anfog.py
+++ b/test_aodndata/anfog/test_anfog.py
@@ -54,6 +54,7 @@ class TestAnfogHandler(HandlerTestCase):
                          'IMOS_ANFOG_BCEOPSTUV_20180503T080042Z_SL210_FV01_timeseries_END-20180505T054942Z.nc')
         self.assertTrue(f.is_checked)
         self.assertTrue(f.is_stored)
+        self.assertTrue(f.is_harvested)
 
     def test_good_anfog_dm_zip(self):
 
@@ -83,6 +84,7 @@ class TestAnfogHandler(HandlerTestCase):
                              'IMOS/ANFOG/slocum_glider/BassStrait20160302/' + nc.name)
             self.assertTrue(nc.is_stored)
             self.assertTrue(nc.is_checked)
+            self.assertTrue(nc.is_harvested)
 
     def test_good_anfog_rt_zip(self):
 
@@ -104,6 +106,7 @@ class TestAnfogHandler(HandlerTestCase):
             self.assertEqual(nc.dest_path,
                              'IMOS/ANFOG/REALTIME/slocum_glider/Forster20180205/' + nc.name)
             self.assertTrue(nc.is_stored)
+            self.assertTrue(nc.is_harvested)
 
     def test_dstg(self):
         # test future Reef Map processing
@@ -117,6 +120,7 @@ class TestAnfogHandler(HandlerTestCase):
         self.assertEqual(f.dest_path,
                          'Department_of_Defence/DSTG/slocum_glider/TalismanSaberB20130706/' + f.name)
         self.assertTrue(f.is_stored)
+        self.assertTrue(f.is_harvested)
 
     def test_good_file_with_compliance_check(self):
         # we also expect this to succeed, since the test file is known be CF compliant
@@ -130,6 +134,7 @@ class TestAnfogHandler(HandlerTestCase):
         self.assertEqual(f.publish_type, PipelineFilePublishType.HARVEST_UPLOAD)
         self.assertTrue(f.is_checked)
         self.assertTrue(f.is_stored)
+        self.assertTrue(f.is_harvested)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
…t attribute setting (i.e. where the setting was the default).

@bpasquer sorry I got a it carried away, but found a few patterns duplicated throughout and refactored them a bit. I started changing a couple of things as a proof of concept for what I was talking about, but ended up being easier to just PR it rather than paste in comments!

Also it now uses the dest_path function in the normal way (i.e. calls it during the publish step rather than needing to explicitly set paths everywhere) for everything except the previous files, because that is a bit trickier with the variable path for RT/DM.

One thing that confused me though... what is the intended purpose of the '_status.txt' file? It currently doesn't look like it actually does anything with it.

