### PR TITLE
Update GenericHandler and MooringsHandler to work with aodncore 0.12

### DIFF
--- a/aodndata/common/generic.py
+++ b/aodndata/common/generic.py
@@ -1,5 +1,5 @@
 from aodncore.pipeline import HandlerBase, PipelineFilePublishType
-from aodncore.pipeline.exceptions import InvalidInputFileError
+from aodncore.pipeline.exceptions import InvalidFileNameError
 
 
 class GenericHandler(HandlerBase):
@@ -26,17 +26,16 @@ class GenericHandler(HandlerBase):
 
     def preprocess(self):
         """Check that every input file is valid according to the include/exclude regex patterns. Any non-matching
-        file will be marked as NO_ACTION after the _resolve step.
+        file will be left with publish_type UNSET after the _resolve step.
 
         :return: None
         """
-        self.logger.info("Running preprocess from child class")
+        self.logger.info("Checking for invalid files.")
 
-        invalid_files = [f.name for f in self.file_collection
-                         if f.publish_type == PipelineFilePublishType.NO_ACTION]
+        invalid_files = self.file_collection.filter_by_attribute_id('publish_type', PipelineFilePublishType.UNSET)
         if invalid_files:
-            raise InvalidInputFileError(
-                "File name(s) don't match the pattern expected for this run location: {name}".format(
-                    name=str(invalid_files)
+            raise InvalidFileNameError(
+                "File name(s) don't match the pattern expected for this upload location: {names}".format(
+                    names=map(str, invalid_files.get_attribute_list('name'))
                 )
             )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-aodncore
+aodncore>=0.12.0
 matplotlib==1.5.1
 pandas==0.22.0

--- a/test_aodndata/common/test_genericHandler.py
+++ b/test_aodndata/common/test_genericHandler.py
@@ -2,7 +2,7 @@ import os
 import unittest
 
 from aodncore.pipeline import PipelineFilePublishType
-from aodncore.pipeline.exceptions import ComplianceCheckFailedError, InvalidInputFileError, InvalidFileContentError
+from aodncore.pipeline.exceptions import ComplianceCheckFailedError, InvalidFileContentError, InvalidFileNameError
 from aodncore.testlib import HandlerTestCase
 from aodndata.common.generic import GenericHandler
 from aodndata.moorings.classifiers import dest_path_anmn_nrs_realtime
@@ -34,7 +34,7 @@ class TestGenericHandler(HandlerTestCase):
                                         dest_path_function=dest_path_anmn_nrs_realtime)
 
     def test_bad_name_netcdf(self):
-        self.run_handler_with_exception(InvalidInputFileError, BAD_NC,
+        self.run_handler_with_exception(InvalidFileNameError, BAD_NC,
                                         include_regexes=['IMOS_ANMN-NRS_.*realtime\.nc'],
                                         dest_path_function=dest_path_anmn_nrs_realtime)
 


### PR DESCRIPTION
This is to account for the new default publish_type introduced by https://github.com/aodn/python-aodncore/pull/91