### PR TITLE
Add cc-plugin-imos dependency (in order to remove from aodncore)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,12 +41,14 @@ ENTRY_POINTS = {
         'dest_path_soop_xbt_nrt = aodndata.soop.soop_xbt_nrt:dest_path_soop_xbt_nrt'
     ],
     'pipeline.module_versions': [
-        'aodndata = aodndata.version:__version__'
+        'aodndata = aodndata.version:__version__',
+        'cc-plugin-imos = cc_plugin_imos:__version__'
     ]
 }
 
 INSTALL_REQUIRES = [
     'aodncore>=0.12.0',
+    'cc-plugin-imos>=1.3.0',
     'matplotlib==1.5.1',
     'pandas==0.22.0'
 ]


### PR DESCRIPTION
This is for discussion as much as anything. I think it makes more sense to have the plugin dependency here rather than aodncore. 

`aodncore` certainly needs the base compliance checker because it is imported directly, but there's no point in testing anything to do with the additional check suites in core. The dependencies really belong to the specific handlers and/or pipelines, which are all defined here.

If defined here, we can then remove the dependency from aodncore for fewer moving parts during environment setup for unit testing etc.