### PR TITLE
Update handlers using state_query to use keys method, for compatibili…

### DIFF
--- a/aodndata/acorn/handler.py
+++ b/aodndata/acorn/handler.py
@@ -103,7 +103,7 @@ class AcornHandler(HandlerBase):
         # if we need to overwrite this object or not
         destination_s3 = self.dest_path(nc_file.name)
 
-        storage_query_res = self.state_query.query_storage(destination_s3)
+        storage_query_res = self.state_query.query_storage(destination_s3).keys()
 
         # creation date of the new file in the pipeline
         if destination_s3 in storage_query_res:

--- a/aodndata/anfog/handlers.py
+++ b/aodndata/anfog/handlers.py
@@ -251,7 +251,7 @@ class AnfogHandler(HandlerBase):
 
         # publish_type set according to file type: netcdf unharvest_delete,
         # everything else (png, txt, kml..) DELETE_ONLY
-        previous_file_list = self.state_query.query_storage(destination)
+        previous_file_list = self.state_query.query_storage(destination).keys()
         self.logger.info("Mode '{mode}' and Status '{status}'".format(mode=mode, status=deployment_status))
 
         for filename in previous_file_list:

--- a/aodndata/gsla/handler.py
+++ b/aodndata/gsla/handler.py
@@ -142,7 +142,7 @@ class GslaHandler(HandlerBase):
         destination = self.dest_path(filepath)
         destination_no_creation_date = re.sub('_C-[0-9]{8}T[0-9]{6}Z.*$', '', destination)
 
-        res = self.state_query.query_storage(destination_no_creation_date)
+        res = self.state_query.query_storage(destination_no_creation_date).keys()
         if len(res) > 1:
             raise RuntimeError('More than 1 previous version of {filename} was found on storage.'.
                                format(filename=os.path.basename(filepath)))

--- a/aodndata/soop/soop_ba.py
+++ b/aodndata/soop/soop_ba.py
@@ -112,7 +112,7 @@ class SoopBaHandler(HandlerBase):
         destination = dest_path_soop_ba(nc)
         nc.dest_path = os.path.join(destination, nc.name)
 
-        results = self.state_query.query_storage(destination)
+        results = self.state_query.query_storage(destination).keys()
         files_to_delete = self.get_previous_version(results, destination, nc.name)
         if files_to_delete:
             self.file_collection.update(files_to_delete)


### PR DESCRIPTION
…ty with upcoming change to use RemotePipelineFileCollection as return type

This is to ensure the handlers will cope with: https://github.com/aodn/python-aodncore/pull/167, as the current assumption is that the return type of `self.state_query.query_storage()` is a "dict of dicts".