### PR TITLE
Moorings products: add download/opendap URL details

### DIFF
--- a/aodndata/moorings/products_handler.py
+++ b/aodndata/moorings/products_handler.py
@@ -94,14 +94,18 @@ class MooringsProductsHandler(HandlerBase):
         self.excluded_files = defaultdict(set)
         for var in self.product_variables:
             # Filter input_list to the files relevant for this var
-            input_list = [f.local_path for f in input_file_collection
-                          if var in input_file_variables[f.dest_path]
+            input_list = [f for f, f_vars in input_file_variables.items()
+                          if var in f_vars
                           ]
             if not input_list:
                 raise InvalidFileContentError("No files to aggregate for {var}".format(var=var))
             self.logger.info("Aggregating {var} ({n} files)".format(var=var, n=len(input_list)))
 
-            product_url, errors = main_aggregator(input_list, var, self.product_site_code, base_path=self.products_dir)
+            product_url, errors = main_aggregator(input_list, var, self.product_site_code, input_dir=self.temp_dir,
+                                                  output_dir=self.products_dir,
+                                                  download_url_prefix="https://s3-ap-southeast-2.amazonaws.com/imos-data/",
+                                                  opendap_url_prefix="http://thredds.aodn.org.au/thredds/dodsC/"
+                                                  )
             if errors:
                 self.logger.warning("{n} files were excluded from the aggregation.".format(n=len(errors)))
                 for f, e in errors.items():

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ INSTALL_REQUIRES = [
     'aodncore>=0.31.0',
     'cc-plugin-imos>=1.3.0',
     'matplotlib==1.5.1',
-    'aodntools>=0.4.3',
+    'aodntools>=0.4.4',
     'pandas==0.24.2'
 ]
 

--- a/test_aodndata/moorings/test_mooringsProductsHandler.py
+++ b/test_aodndata/moorings/test_mooringsProductsHandler.py
@@ -1,15 +1,11 @@
 import httpretty
 import json
 import os
-import re
 import unittest
 
 from aodncore.pipeline import PipelineFileCollection, PipelineFile, PipelineFilePublishType
-from aodncore.pipeline.exceptions import ComplianceCheckFailedError, InvalidFileContentError, InvalidFileNameError
 from aodncore.pipeline.storage import get_storage_broker
-from aodncore.testlib import HandlerTestCase, make_zip
-
-from aodntools.timeseries_products.aggregated_timeseries import main_aggregator
+from aodncore.testlib import HandlerTestCase
 
 from aodndata.moorings.products_handler import MooringsProductsHandler
 


### PR DESCRIPTION
Add more useful metadata to the aggregated timeseries products generated, using the additional arguments introduced in https://github.com/aodn/python-aodntools/pull/78

(Also a bit of code clean-up.)