### PR TITLE
Stop doing Travis tests in python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.7"
   - "3.5"
   - "3.6"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ matrix:
       env: STAGE="build"
     - name: "systest artefacts"
       env: STAGE="systest"
-    - name: "prod artefacts"
-      env: STAGE="prod"
 
 install:
   - ./scripts/install_dependencies.sh


### PR DESCRIPTION
We are now running this code under python 3.5 everywhere, so we shouldn't need to test under 2.7 anymore.