### PR TITLE
Fix test data path for test_nrmn.py

### DIFF
--- a/test_aodndata/nrmn/test_nrmn.py
+++ b/test_aodndata/nrmn/test_nrmn.py
@@ -11,8 +11,7 @@ from aodncore.pipeline import FileType, PipelineFilePublishType, PipelineFileChe
 from aodncore.testlib import HandlerTestCase
 from aodndata.nrmn.handler import NrmnHandler
 
-TEST_ROOT = "/home/anaberger/aodn/chef/src/tmp/NRMN"
-# TEST_ROOT = os.path.join(os.path.dirname(__file__))
+TEST_ROOT = os.path.join(os.path.dirname(__file__))
 
 NRMN_GOOD_ZIP_BASENAME = "NRMN_public_endpoints.zip"
 NRMN_GOOD_ZIP = os.path.join(TEST_ROOT, "NRMN_public_endpoints.zip")


### PR DESCRIPTION
@ana-berger @bpasquer This PR https://github.com/aodn/python-aodndata/pull/237 looks to have broken the build of this package due to containing references to local files which are the unavailable for the tests when they are run.

In addition to the below change to revert the TEST_ROOT, these files need to be committed to the repo so that automated tests can be run:
* test_aodndata/nrmn/ep_m1_public.csv
* test_aodndata/nrmn/NRMN_public_endpoints.zip

TEST_ROOT in this case is just the same directory as the test_*.py file, so any test data files required for testing just need to be copied into here and checked in.

We always need have a "green traffic light" on a PR before merging to master to avoid creating build failures because of a broken master branch. So it should always look like this before hitting the merge button:

![image](https://user-images.githubusercontent.com/19319040/102426072-bd30d980-4062-11eb-81a9-38a286d01395.png)
