### PR TITLE
Updates to make use of aodncore API improvements

### DIFF
--- a/aodndata/moorings/handlers.py
+++ b/aodndata/moorings/handlers.py
@@ -59,9 +59,8 @@ class MooringsHandler(HandlerBase):
 
             self.logger.info("Burst-processing {f.name}".format(f=f))
             product_path = create_burst_average_netcdf(f.src_path, self.products_dir)
-            product_file = PipelineFile(product_path, file_update_callback=self._file_update_callback)
-            product_file.publish_type = PipelineFilePublishType.HARVEST_UPLOAD
-            self.file_collection.add(product_file)
+            product_file = PipelineFile(product_path, publish_type=PipelineFilePublishType.HARVEST_UPLOAD)
+            self.add_pipelinefile(product_file)
 
     def postprocess(self):
         """Set error_cleanup_regexes so that if the same file was uploaded previously and failed, it can now be
@@ -116,6 +115,6 @@ class DwmHandler(MooringsHandler):
 
             self.file_collection.set_publish_types(PipelineFilePublishType.NO_ACTION)
             self.input_file_object.publish_type = PipelineFilePublishType.HARVEST_UPLOAD
-            self.file_collection.add(self.input_file_object)
+            self.add_pipelinefile(self.input_file_object)
 
     dest_path = DwmFileClassifier.dest_path

--- a/aodndata/moorings/products_handler.py
+++ b/aodndata/moorings/products_handler.py
@@ -201,7 +201,7 @@ class MooringsProductsHandler(HandlerBase):
 
         # Download input files to local cache.
         self.logger.info("Downloading {n} input files".format(n=len(self.input_file_collection)))
-        self.input_file_collection.download(self._upload_store_runner.broker, self.temp_dir)
+        self.state_query.download(self.input_file_collection, self.temp_dir)
         # TODO: Replace temp_dir above with cache_dir?
 
     def _get_old_product_files(self):
@@ -242,9 +242,8 @@ class MooringsProductsHandler(HandlerBase):
 
     def _add_to_collection(self, product_url):
         """Add a new product file to the file_collection to be harvested and uploaded."""
-        product_file = PipelineFile(product_url, file_update_callback=self._file_update_callback)
-        product_file.publish_type = PipelineFilePublishType.HARVEST_UPLOAD
-        self.file_collection.add(product_file)
+        product_file = PipelineFile(product_url, publish_type = PipelineFilePublishType.HARVEST_UPLOAD)
+        self.add_pipelinefile(product_file)
 
     def _input_list_for_variables(self, *variables):
         """Return a list of input files containing any of the given variables"""
@@ -357,10 +356,10 @@ class MooringsProductsHandler(HandlerBase):
             if os.path.basename(old_product_url) != product_filename:
                 # Add the previous version as a "late deletion". It will be deleted during the handler's `publish`
                 # step after (and only if) all new files have been successfully published.
-                old_file = PipelineFile(old_product_url, dest_path=old_product_url, is_deletion=True,
-                                        late_deletion=True, file_update_callback=self._file_update_callback)
-                old_file.publish_type = PipelineFilePublishType.DELETE_UNHARVEST
-                self.file_collection.add(old_file)
+                old_file = PipelineFile(old_product_url, dest_path=old_product_url,
+                                        is_deletion=True, late_deletion=True,
+                                        publish_type=PipelineFilePublishType.DELETE_UNHARVEST)
+                self.add_pipelinefile(old_file)
 
     def preprocess(self):
         """If the input is a manifest file, collect available input files and


### PR DESCRIPTION
https://github.com/aodn/python-aodncore/pull/209 introduces a couple of API improvements for:
* handlers explicitly creating and adding `PipelineFile` objects to their `file_collection`; and
* handlers downloading remote files
The old functionality is still there, but now issues deprecation warnings. 

This PR is to update all handlers to use the new API, so the old methods can be removed in a future aodncore update.