### PR TITLE
Add vocab module (moved from aodncore). Update SoopXbtNrtHandler to h…

### DIFF
--- a/aodndata/soop/ship_callsign.py
+++ b/aodndata/soop/ship_callsign.py
@@ -13,7 +13,7 @@ How to use:
 author : Besnard, Laurent
 """
 
-from aodncore.vocab.platform_code_vocab import platform_altlabels_per_preflabel
+from aodndata.vocab.platform_code_vocab import platform_altlabels_per_preflabel
 
 try:
     from functools import lru_cache

--- a/aodndata/soop/soop_xbt_nrt.py
+++ b/aodndata/soop/soop_xbt_nrt.py
@@ -12,7 +12,7 @@ from pkg_resources import resource_filename
 
 from aodncore.pipeline import FileType, HandlerBase, PipelineFilePublishType, PipelineFile
 from aodncore.pipeline.exceptions import InvalidFileContentError, MissingConfigParameterError
-from aodncore.vocab.xbt_line_vocab import XbtLineVocabHelper
+from aodndata.vocab.xbt_line_vocab import XbtLineVocabHelper, DEFAULT_XBT_LINE_VOCAB_URL
 from .ship_callsign import ship_callsign_list
 
 BUFR_VAR = ({
@@ -66,12 +66,10 @@ class SoopXbtNrtHandler(HandlerBase):
         super(SoopXbtNrtHandler, self).__init__(*args, **kwargs)
         self.allowed_extensions = ['.nc', '.csv']
 
-        try:
-            self.xbt_line_vocab_url = self.config.pipeline_config['global']['xbt_line_vocab_url']
-        except KeyError:
-            raise MissingConfigParameterError(
-                "missing required config item 'xbt_line_vocab_url' in the pipeline config"
-            )
+        if self.custom_params is None or not self.custom_params.get('xbt_line_vocab_url'):
+            self.xbt_line_vocab_url = DEFAULT_XBT_LINE_VOCAB_URL
+        else:
+            self.xbt_line_vocab_url = self.custom_params['xbt_line_vocab_url']
 
     def preprocess(self):
         """

--- a/aodndata/vocab/__init__.py
+++ b/aodndata/vocab/__init__.py
@@ -1,0 +1,7 @@
+from .platform_code_vocab import PlatformVocabHelper, platform_altlabels_per_preflabel, platform_type_uris_by_category
+
+__all__ = [
+    'PlatformVocabHelper',
+    'platform_altlabels_per_preflabel',
+    'platform_type_uris_by_category'
+]

--- a/aodndata/vocab/platform_code_vocab.py
+++ b/aodndata/vocab/platform_code_vocab.py
@@ -1,0 +1,149 @@
+"""
+Find the platform_code platform_name equivalence from poolparty platform vocab
+xml file stored in content.aodn.org.au
+
+How to use:
+    from platform_code_vocab import *
+
+    platform_altlabels_per_preflabel()
+    platform_type_uris_by_category()
+    platform_altlabels_per_preflabel('Fixed station')
+    platform_altlabels_per_preflabel('Mooring and buoy')
+    platform_altlabels_per_preflabel('Vessel')
+
+author : Besnard, Laurent
+"""
+
+import warnings
+from urllib.request import urlopen
+import xml.etree.ElementTree as ET
+
+DEFAULT_PLATFORM_CAT_VOCAB_URL = 'http://content.aodn.org.au/Vocabularies/platform-category/aodn_aodn-platform-category-vocabulary.rdf'
+DEFAULT_PLATFORM_VOCAB_URL = 'http://content.aodn.org.au/Vocabularies/platform/aodn_aodn-platform-vocabulary.rdf'
+
+
+def platform_type_uris_by_category(platform_cat_vocab_url=DEFAULT_PLATFORM_CAT_VOCAB_URL):
+    """DEPRECATED: this provides compatibility for existing code, until it is refactored to use the class-based interface
+
+    :param platform_cat_vocab_url:
+    :return:
+    """
+    helper = PlatformVocabHelper(DEFAULT_PLATFORM_VOCAB_URL, platform_cat_vocab_url)
+    return helper.platform_type_uris_by_category()
+
+
+def platform_altlabels_per_preflabel(category_name, platform_vocab_url=DEFAULT_PLATFORM_VOCAB_URL):
+    """DEPRECATED: this provides compatibility for existing code, until it is refactored to use the class-based interface
+
+    :param category_name:
+    :param platform_vocab_url:
+    :return:
+    """
+    helper = PlatformVocabHelper(platform_vocab_url, DEFAULT_PLATFORM_CAT_VOCAB_URL)
+    return helper.platform_altlabels_per_preflabel(category_name)
+
+
+class PlatformVocabHelper(object):
+    def __init__(self, platform_vocab_url, platform_cat_vocab_url):
+        self.platform_vocab_url = platform_vocab_url
+        self.platform_cat_vocab_url = platform_cat_vocab_url
+
+    def platform_type_uris_by_category(self):
+        """
+        retrieves a list of platform category and their narrowMatch url type which
+        defines their category
+        """
+        response = urlopen(self.platform_cat_vocab_url)
+        html = response.read()
+        root = ET.fromstring(html)
+        platform_cat_list = {}
+
+        for item in root:
+            if 'Description' in item.tag:
+                platform_cat_url_list = []
+                platform_cat = None
+
+                for val in item:
+                    platform_element_sublabels = val.tag
+
+                    # handle more than 1 url match per category of platform
+                    if platform_element_sublabels is not None:
+                        if 'narrowMatch' in platform_element_sublabels:
+                            val_cat_url = list(val.attrib.values())[0]
+                            platform_cat_url_list.append(val_cat_url)
+
+                        elif 'prefLabel' in platform_element_sublabels:
+                            platform_cat = val.text
+
+                if platform_cat is not None and platform_cat_url_list:
+                    platform_cat_list[platform_cat] = platform_cat_url_list
+
+        response.close()
+        return platform_cat_list
+
+    def platform_altlabels_per_preflabel(self, category_name):
+        """
+        retrieves a list of platform code - platform name dictionnary.
+        The function can either retrieves ALL platform codes, or only platform codes
+        for a specific category, which can be found in platform_type_uris_by_category()
+
+        Example:
+            platform_altlabels_per_preflabel()
+            platform_altlabels_per_preflabel('Vessel')
+        """
+        response = urlopen(self.platform_vocab_url)
+        html = response.read()
+        root = ET.fromstring(html)
+        platform = {}
+        filter_cat_type = False
+
+        if category_name:
+            # a platform category is defined by a list of urls.
+            # first we check the category exist in the category list, secondly we
+            # get the list of url vocab attached to this category
+            filter_cat_name = category_name
+            filter_cat_list = self.platform_type_uris_by_category()
+            if filter_cat_name in filter_cat_list.keys():
+                filter_cat_url_list = filter_cat_list[filter_cat_name]
+                filter_cat_type = True
+            else:
+                warnings.warn("Platform category %s not in platform category vocabulary" % filter_cat_name)
+
+        for item in root:
+            # main element name we're interested in
+            if 'Description' in item.tag:
+                # for every element, iterate over the sub elements and look for
+                # common platform label
+                platform_code = []
+                platform_name = None
+                platform_url_cat = None
+
+                for val in item:
+                    platform_element_sublabels = val.tag
+
+                    # handle more than 1 alternative label for same pref label
+                    if platform_element_sublabels is not None:
+                        if 'altLabel' in platform_element_sublabels:
+                            platform_code.append(val.text)
+
+                        elif 'prefLabel' in platform_element_sublabels:
+                            platform_name = val.text
+
+                        elif 'broader' in platform_element_sublabels:
+                            val_cat_url = list(val.attrib.values())[0]
+                            platform_url_cat = val_cat_url
+
+                # use the optional argument
+                if filter_cat_type:
+                    if platform_url_cat in filter_cat_url_list:
+                        if platform_name is not None and platform_code:
+                            for platform_code_item in platform_code:
+                                platform[platform_code_item] = platform_name
+
+                else:
+                    if platform_name is not None and platform_code:
+                        for platform_code_item in platform_code:
+                            platform[platform_code_item] = platform_name
+
+        response.close()
+        return platform

--- a/aodndata/vocab/xbt_line_vocab.py
+++ b/aodndata/vocab/xbt_line_vocab.py
@@ -1,0 +1,59 @@
+"""
+Parse XBT line vocabulary from vocabs.ands.org.au
+"""
+
+import os
+import urllib.request, urllib.error, urllib.parse
+import xml.etree.ElementTree as ET
+try:
+    from functools import lru_cache
+except ImportError:  # pragma: no cover
+    from functools32 import lru_cache
+
+DEFAULT_XBT_LINE_VOCAB_URL = 'http://content.aodn.org.au/Vocabularies/XBT-line/aodn_aodn-xbt-line-vocabulary.rdf'
+
+class XbtLineVocabHelper(object):
+    def __init__(self, xbt_line_vocab_url):
+        self.xbt_line_vocab_url = xbt_line_vocab_url
+
+    @lru_cache(maxsize=32)
+    def xbt_line_info(self):
+        """
+        retrieves a dictionary of xbt line codes with their IMOS code equivalent if available
+        """
+        response = urllib.request.urlopen(self.xbt_line_vocab_url)
+        html = response.read()
+        root = ET.fromstring(html)
+
+        xbt_dict = {}
+
+        for item in root:
+            if 'Description' in item.tag:
+                xbt_line_code = None  # xbt_line_code
+                xbt_line_pref_label = None  # xbt_line_code IMOS preferred value
+                xbt_line_alt_label = None  # xbt line description, sometimes multiple altlabels such as AX01,
+                # AX10, but these are not used by IMOS/AODN, so no need to make the code more complicated
+
+                for val in item:
+                    platform_element_sublabels = val.tag
+                    if platform_element_sublabels is not None:
+                        if 'prefLabel' in platform_element_sublabels:
+                            xbt_line_pref_label = val.text
+                        if 'code' in platform_element_sublabels:
+                            xbt_line_code = val.text
+                        if 'altLabel' in platform_element_sublabels:  #
+                            xbt_line_alt_label = val.text
+
+                if xbt_line_code is None and xbt_line_pref_label is not None:
+                    xbt_dict[xbt_line_pref_label] = ({
+                        'xbt_pref_label': xbt_line_pref_label,
+                        'xbt_line_description': xbt_line_alt_label
+                    })
+                elif xbt_line_code is not None:
+                    xbt_dict[xbt_line_code] = ({
+                        'xbt_pref_label': xbt_line_pref_label,
+                        'xbt_line_description': xbt_line_alt_label
+                    })
+
+        response.close()
+        return xbt_dict

--- a/test_aodndata/soop/test_soop_xbt_nrt.py
+++ b/test_aodndata/soop/test_soop_xbt_nrt.py
@@ -12,6 +12,8 @@ from aodndata.soop.soop_xbt_nrt import SoopXbtNrtHandler, xbt_line_get_info, par
     fzf_vessel_get_info
 from aodndata.soop.ship_callsign import ship_callsign_list
 
+from test_aodndata.vocab import TEST_XBT_LINE_VOCAB_URL
+
 TEST_ROOT = os.path.join(os.path.dirname(__file__))
 GOOD_BUFR_CSV = os.path.join(TEST_ROOT,
                        'IOSS01_AMMC_20201109215900_XEKXW9W.csv')
@@ -42,7 +44,7 @@ class TestSoopXbtNrtHandler(HandlerTestCase):
 
         self.handler_class = SoopXbtNrtHandler
         super(TestSoopXbtNrtHandler, self).setUp()
-        self.url = self.config.pipeline_config['global']['xbt_line_vocab_url']
+        self.url = TEST_XBT_LINE_VOCAB_URL
         self.good_profile = ({
             'profile_metadata':  ({''
                                    'XBT_line': "IX8",
@@ -132,7 +134,8 @@ class TestSoopXbtNrtHandler(HandlerTestCase):
            side_effect=mock_platform_altlabels_per_preflabel)
     def test_handler(self, mock_ship):
         handler = self.run_handler(GOOD_BUFR_CSV,
-                                   check_params={'checks': ['cf', 'imos:1.4']})
+                                   check_params={'checks': ['cf', 'imos:1.4']},
+                                   custom_params={'xbt_line_vocab_url': TEST_XBT_LINE_VOCAB_URL})
 
         f_nc = handler.file_collection.filter_by_attribute_id('file_type', FileType.NETCDF)[0]
         f_csv = handler.file_collection.filter_by_attribute_id('file_type', FileType.CSV)[0]
@@ -161,7 +164,8 @@ class TestSoopXbtNrtHandler(HandlerTestCase):
 
         # test the handler by pushing this newly created NetCDF file back into the handler
         handler = self.run_handler(nc_path,
-                                   check_params={'checks': ['cf', 'imos:1.4']})
+                                   check_params={'checks': ['cf', 'imos:1.4']},
+                                   custom_params={'xbt_line_vocab_url': TEST_XBT_LINE_VOCAB_URL})
         f_nc = handler.file_collection.filter_by_attribute_id('file_type', FileType.NETCDF)[0]
         self.assertEqual(f_nc.publish_type, PipelineFilePublishType.HARVEST_UPLOAD)
 
@@ -170,7 +174,8 @@ class TestSoopXbtNrtHandler(HandlerTestCase):
            side_effect=mock_platform_altlabels_per_preflabel)
     def test_handler_px30(self, mock_ship):
         handler = self.run_handler(GOOD_BUFR_CSV_PX30,
-                                   check_params={'checks': ['cf', 'imos:1.4']})
+                                   check_params={'checks': ['cf', 'imos:1.4']},
+                                   custom_params={'xbt_line_vocab_url': TEST_XBT_LINE_VOCAB_URL})
 
         f_nc = handler.file_collection.filter_by_attribute_id('file_type', FileType.NETCDF)[0]
         self.assertEqual(f_nc.publish_type, PipelineFilePublishType.HARVEST_UPLOAD)
@@ -184,7 +189,8 @@ class TestSoopXbtNrtHandler(HandlerTestCase):
            side_effect=mock_platform_altlabels_per_preflabel)
     def test_handler_noline(self, mock_ship):
         handler = self.run_handler(BUFR_CSV_NO_LINE,
-                                   check_params={'checks': ['cf', 'imos:1.4']})
+                                   check_params={'checks': ['cf', 'imos:1.4']},
+                                   custom_params={'xbt_line_vocab_url': TEST_XBT_LINE_VOCAB_URL})
 
         f_nc = handler.file_collection.filter_by_attribute_id('file_type', FileType.NETCDF)[0]
         self.assertEqual(f_nc.publish_type, PipelineFilePublishType.HARVEST_UPLOAD)

--- a/test_aodndata/vocab/__init__.py
+++ b/test_aodndata/vocab/__init__.py
@@ -1,0 +1,8 @@
+from .test_platform_code_vocab import TEST_PLATFORM_CAT_VOCAB_URL, TEST_PLATFORM_VOCAB_URL
+from .test_xbt_line_vocab import TEST_XBT_LINE_VOCAB_URL
+
+__all__ = [
+    'TEST_PLATFORM_CAT_VOCAB_URL',
+    'TEST_PLATFORM_VOCAB_URL',
+    'TEST_XBT_LINE_VOCAB_URL'
+]

--- a/test_aodndata/vocab/aodn_aodn-platform-category-vocabulary.rdf
+++ b/test_aodndata/vocab/aodn_aodn-platform-category-vocabulary.rdf
@@ -1,0 +1,819 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:owl="http://www.w3.org/2002/07/owl#"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+	xmlns:fn="http://www.w3.org/2005/xpath-functions#"
+	xmlns:dcterms="http://purl.org/dc/terms/"
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+	xmlns:sesame="http://www.openrdf.org/schema/sesame#"
+	xmlns:foaf="http://xmlns.com/foaf/0.1/"
+	xmlns:cycAnnot="http://sw.cyc.com/CycAnnotations_v1#"
+	xmlns:csw="http://semantic-web.at/ontologies/csw.owl#"
+	xmlns:freebase="http://rdf.freebase.com/ns/"
+	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+	xmlns:dbpedia="http://dbpedia.org/resource/"
+	xmlns:cyc="http://sw.cyc.com/concept/"
+	xmlns:tags="http://www.holygoat.co.uk/owl/redwood/0.1/tags/"
+	xmlns:opencyc="http://sw.opencyc.org/concept/"
+	xmlns:ctag="http://commontag.org/ns#"
+	xmlns:dc="http://purl.org/dc/elements/1.1/">
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#subject">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#subject"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#object">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#object"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#first">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#first"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#rest">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+	<rdfs:range rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#rest"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#value">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#value"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#List">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#domain">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#domain"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#Resource">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#range">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#range"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#subPropertyOf">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdfs:range rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#subPropertyOf"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#subClassOf">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#Class">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#member">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#member"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#seeAlso">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#seeAlso"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#isDefinedBy">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#seeAlso"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#isDefinedBy"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#comment">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#comment"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#label">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#Literal">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#Alt">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Alt"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Container"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#Container">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Container"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#Bag">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Container"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Bag"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#Seq">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Container"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Seq"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#ContainerMembershipProperty">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#ContainerMembershipProperty"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Datatype"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#Datatype">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Datatype"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://editor.vocabs.ands.org.au/user/Natalia_Atkins">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://purl.org/dc/terms/Agent"/>
+	<foaf:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Natalia_Atkins</foaf:name>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/terms/Agent">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subClassOf rdf:resource="http://purl.org/dc/terms/Agent"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://xmlns.com/foaf/0.1/name">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://xmlns.com/foaf/0.1/name"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://purl.org/dc/terms/Agent"/>
+	<foaf:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sebastien-Mancini</foaf:name>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://editor.vocabs.ands.org.au/user/Sebastien_Mancini">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://purl.org/dc/terms/Agent"/>
+	<foaf:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sebastien_Mancini</foaf:name>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://purl.org/dc/terms/Agent"/>
+	<foaf:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMII_Atkins.Natalia</foaf:name>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://purl.org/dc/terms/Agent"/>
+	<foaf:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMII_Finney.Kim_Admin</foaf:name>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://editor.vocabs.ands.org.au/user/eMarine-Information-Infrastructure-eMII">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://purl.org/dc/terms/Agent"/>
+	<foaf:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine-Information-Infrastructure-eMII</foaf:name>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform_classes/1">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+	<dc:rights rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Freely Available For Reuse</dc:rights>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2014-06-01T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dcterms:description xml:lang="en">A classification scheme to support faceted searching across platform types in the IMOS 123 Portal.</dcterms:description>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-16T03:50:11Z</dcterms:modified>
+	<dcterms:publisher rdf:resource="http://editor.vocabs.ands.org.au/user/eMarine-Information-Infrastructure-eMII"/>
+	<dcterms:subject xml:lang="en">platform category</dcterms:subject>
+	<dcterms:title xml:lang="en">AODN Platform Category Vocabulary</dcterms:title>
+	<identifier xmlns="http://schema.semantic-web.at/ppt/" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">category</identifier>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/35"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/36"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/37"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/39"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/40"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/41"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/42"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/43"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/44"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/platform_classes/2"/>
+	<dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2017-07-03</dcterms:issued>
+	<owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Version 1.1</owl:versionInfo>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/elements/1.1/rights">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://purl.org/dc/elements/1.1/rights"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/terms/contributor">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/contributor"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/terms/created">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/created"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/terms/creator">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/creator"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/terms/description">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/description"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/terms/modified">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/modified"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/terms/publisher">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/publisher"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/terms/subject">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/subject"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/terms/title">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/title"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://schema.semantic-web.at/ppt/identifier">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://schema.semantic-web.at/ppt/identifier"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#ConceptScheme">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#hasTopConcept">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#hasTopConcept"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform_classes/category/35">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/Natalia_Atkins"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2014-06-01T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-06T04:40:39Z</dcterms:modified>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform category register</dc:source>
+	<skos:definition xml:lang="en">This category contains vocabulary terms describing AUV type of platforms</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform_classes/1"/>
+	<skos:narrowMatch rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/12"/>
+	<skos:narrowMatch rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/23"/>
+	<skos:narrowMatch rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/25"/>
+	<skos:narrowMatch rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/26"/>
+	<skos:prefLabel xml:lang="en">AUV</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform_classes/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform_classes/category/36">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/Natalia_Atkins"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2014-06-01T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-06T04:39:26Z</dcterms:modified>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform category register</dc:source>
+	<skos:definition xml:lang="en">This category contains vocabulary terms describing fixed stations type of platform</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform_classes/1"/>
+	<skos:narrowMatch rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/11"/>
+	<skos:narrowMatch rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/14"/>
+	<skos:narrowMatch rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/16"/>
+	<skos:narrowMatch rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/17"/>
+	<skos:prefLabel xml:lang="en">Fixed station</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform_classes/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform_classes/category/37">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2014-06-01T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T01:37:04Z</dcterms:modified>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform category register</dc:source>
+	<skos:definition xml:lang="en">This category contains vocabulary terms describing profiling float type of platform</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform_classes/1"/>
+	<skos:narrowMatch rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/42"/>
+	<skos:narrowMatch rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/45"/>
+	<skos:narrowMatch rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/46"/>
+	<skos:prefLabel xml:lang="en">Float</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform_classes/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform_classes/category/39">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2014-06-01T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-15T23:43:37Z</dcterms:modified>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform category register</dc:source>
+	<skos:definition xml:lang="en">This category contains vocabulary terms describing ship type of platform</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform_classes/1"/>
+	<skos:narrowMatch rdf:resource="http://vocab.aodn.org.au/def/platform/entity/823"/>
+	<skos:narrowMatch rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/30"/>
+	<skos:narrowMatch rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/31"/>
+	<skos:narrowMatch rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:narrowMatch rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/33"/>
+	<skos:narrowMatch rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/35"/>
+	<skos:narrowMatch rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/36"/>
+	<skos:narrowMatch rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/37"/>
+	<skos:narrowMatch rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/38"/>
+	<skos:narrowMatch rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/39"/>
+	<skos:narrowMatch rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/3A"/>
+	<skos:prefLabel xml:lang="en">Vessel</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform_classes/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform_classes/category/40">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2014-06-01T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-07-03T05:46:49Z</dcterms:modified>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform category register</dc:source>
+	<skos:definition xml:lang="en">This category contains vocabulary terms describing animal type of platform</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform_classes/1"/>
+	<skos:narrowMatch rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/75"/>
+	<skos:narrowMatch rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/71"/>
+	<skos:narrowMatch rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/70"/>
+	<skos:narrowMatch rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/72"/>
+	<skos:narrowMatch rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/73"/>
+	<skos:narrowMatch rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/74"/>
+	<skos:narrowMatch rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/77"/>
+	<skos:narrowMatch rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/76"/>
+	<skos:prefLabel xml:lang="en">Biological platform</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform_classes/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform_classes/category/41">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/Natalia_Atkins"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2014-06-01T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-06T04:39:33Z</dcterms:modified>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform category register</dc:source>
+	<skos:definition xml:lang="en">This category contains vocabulary terms describing satellite type of platform</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform_classes/1"/>
+	<skos:narrowMatch rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/64"/>
+	<skos:narrowMatch rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/65"/>
+	<skos:prefLabel xml:lang="en">Satellite</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform_classes/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform_classes/category/42">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2014-06-01T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T00:28:03Z</dcterms:modified>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform category register</dc:source>
+	<skos:definition xml:lang="en">This category contains vocabulary terms describing radar type of platform</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform_classes/1"/>
+	<skos:narrowMatch rdf:resource="http://vocab.aodn.org.au/def/platform/entity/726"/>
+	<skos:narrowMatch rdf:resource="http://vocab.aodn.org.au/def/platform/entity/727"/>
+	<skos:prefLabel xml:lang="en">Radar</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform_classes/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform_classes/category/43">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2014-06-01T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T01:02:06Z</dcterms:modified>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform category register</dc:source>
+	<skos:definition xml:lang="en">This category contains vocabulary terms describing glider type of platform</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform_classes/1"/>
+	<skos:narrowMatch rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/27"/>
+	<skos:prefLabel xml:lang="en">Glider</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform_classes/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform_classes/category/44">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/Natalia_Atkins"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2014-06-01T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-06T04:40:32Z</dcterms:modified>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform category register</dc:source>
+	<skos:definition xml:lang="en">This category contains vocabulary terms describing mooring type of platform</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform_classes/1"/>
+	<skos:narrowMatch rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/41"/>
+	<skos:narrowMatch rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/43"/>
+	<skos:narrowMatch rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:prefLabel xml:lang="en">Mooring and buoy</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform_classes/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/elements/1.1/publisher">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://purl.org/dc/elements/1.1/publisher"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/elements/1.1/source">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://purl.org/dc/elements/1.1/source"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#Concept">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#definition">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#inScheme">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#inScheme"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#narrowMatch">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#narrowMatch"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/12">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/23">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/25">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/26">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#prefLabel">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#prefLabel"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#topConceptOf">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#topConceptOf"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/11">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/14">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/16">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/17">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/42">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/45">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/46">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/823">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/30">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/31">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/32">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/33">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/35">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/36">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/37">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/38">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/39">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/3A">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/75">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/71">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/70">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/72">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/73">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/74">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/77">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/64">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/65">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/726">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/727">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/27">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/41">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/43">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/48">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/76">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform_classes/2">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-07-03T06:25:19Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-07-03T06:28:37Z</dcterms:modified>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform category register</dc:source>
+	<skos:definition xml:lang="en">This category contains vocabulary terms describing aircraft type of platform</skos:definition>
+	<skos:narrowMatch rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/62"/>
+	<skos:narrowMatch rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/61"/>
+	<skos:narrowMatch rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/67"/>
+	<skos:narrowMatch rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/6A"/>
+	<skos:prefLabel xml:lang="en">Aircraft</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform_classes/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/62">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/61">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/67">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/6A">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/terms/issued">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/issued"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2002/07/owl#versionInfo">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#versionInfo"/>
+</rdf:Description>
+
+</rdf:RDF>

--- a/test_aodndata/vocab/aodn_aodn-platform-vocabulary.rdf
+++ b/test_aodndata/vocab/aodn_aodn-platform-vocabulary.rdf
@@ -1,0 +1,10600 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+	xmlns:cycAnnot="http://sw.cyc.com/CycAnnotations_v1#"
+	xmlns:skosxl="http://www.w3.org/2008/05/skos-xl#"
+	xmlns:owl="http://www.w3.org/2002/07/owl#"
+	xmlns:csw="http://semantic-web.at/ontologies/csw.owl#"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+	xmlns:freebase="http://rdf.freebase.com/ns/"
+	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+	xmlns:dbpedia="http://dbpedia.org/resource/"
+	xmlns:cyc="http://sw.cyc.com/concept/"
+	xmlns:tags="http://www.holygoat.co.uk/owl/redwood/0.1/tags/"
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:opencyc="http://sw.opencyc.org/concept/"
+	xmlns:dcterms="http://purl.org/dc/terms/"
+	xmlns:ctag="http://commontag.org/ns#"
+	xmlns:foaf="http://xmlns.com/foaf/0.1/"
+	xmlns:dc="http://purl.org/dc/elements/1.1/"
+	xmlns:fn="http://www.w3.org/2005/xpath-functions#"
+	xmlns:sesame="http://www.openrdf.org/schema/sesame#">
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#subject">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#subject"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#object">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#object"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#first">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#first"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#rest">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+	<rdfs:range rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#rest"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#value">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#value"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#List">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#domain">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#domain"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#Resource">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#range">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#range"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#subPropertyOf">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdfs:range rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#subPropertyOf"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#subClassOf">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#Class">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#member">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#member"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#seeAlso">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#seeAlso"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#isDefinedBy">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#seeAlso"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#isDefinedBy"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#comment">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#comment"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#label">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#Literal">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#Alt">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Alt"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Container"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#Container">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Container"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#Bag">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Container"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Bag"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#Seq">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Container"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Seq"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#ContainerMembershipProperty">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#ContainerMembershipProperty"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Datatype"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#Datatype">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Datatype"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/39">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Iver</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-10-04T05:48:02Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-10-04T05:53:24Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/25"/>
+	<skos:definition xml:lang="en">The IMOS AUV facility operates a small ocean going AUV called Iver from Ocean Server. Managed by the University of Sydney's Australian Centre for Field Robotics (ACFR), this vehicle is able to be launched from the shore or a small boat, and is used in the support of marine habitat assessment as well as in the surveying of archaeological sites in coastal environments. </skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#prefLabel">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#prefLabel"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/163">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Deep-Slope Mooring (M7)</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T06:05:11Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">SAM7DS</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Deep Slope Mooring (M7) is operated by SARDI (South Australian Research and Development Institute), and was a South Australian regional mooring. This mooring was decommissioned in March 2014. </skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-36.1809,nominal longitude:135.8439,nominal depth:500m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/157"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/158"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/159"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/160"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/161"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/162"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/164"/>
+	<dcterms:valid xml:lang="en">2009-12-15/2014-03-12</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/terms/contributor">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/contributor"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://purl.org/dc/terms/Agent"/>
+	<foaf:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMII_Atkins.Natalia_Admin</foaf:name>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/1">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dc:rights rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Freely Available For Reuse</dc:rights>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2012-12-10T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dcterms:description xml:lang="en">A controlled vocabulary for platforms that can be used in Marine Community Profile metadata. This vocabulary will be used by the faceted search on the AODN/IMOS portal.</dcterms:description>
+	<dcterms:identifier xml:lang="en">entity</dcterms:identifier>
+	<dcterms:publisher rdf:resource="http://editor.vocabs.ands.org.au/user/eMarine-Information-Infrastructure-eMII"/>
+	<dcterms:subject xml:lang="en">platform</dcterms:subject>
+	<dcterms:title xml:lang="en">AODN Platform Vocabulary</dcterms:title>
+	<identifier xmlns="http://schema.semantic-web.at/ppt/" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">entity</identifier>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/163"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/25"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/1"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/10"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/100"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/101"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/102"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/103"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/104"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/105"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/106"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/107"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/108"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/109"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/11"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/110"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/111"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/112"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/113"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/114"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/115"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/116"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/117"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/118"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/119"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/12"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/120"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/121"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/122"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/123"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/124"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/125"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/126"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/127"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/128"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/129"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/13"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/130"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/131"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/132"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/133"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/134"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/135"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/136"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/137"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/138"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/139"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/14"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/140"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/141"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/142"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/143"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/144"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/145"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/146"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/147"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/148"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/149"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/15"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/150"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/151"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/152"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/153"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/154"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/155"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/156"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/157"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/158"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/159"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/160"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/161"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/162"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/164"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/165"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/166"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/167"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/168"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/169"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/17"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/170"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/171"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/172"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/173"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/174"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/175"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/176"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/177"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/178"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/179"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/18"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/180"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/181"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/187"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/188"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/189"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/19"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/190"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/191"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/192"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/193"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/194"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/195"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/196"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/197"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/198"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/199"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/2"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/20"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/200"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/201"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/202"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/203"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/204"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/205"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/206"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/207"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/208"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/209"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/21"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/210"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/211"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/212"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/213"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/214"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/215"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/216"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/217"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/218"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/219"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/22"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/220"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/221"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/222"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/223"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/224"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/225"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/226"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/227"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/228"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/229"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/23"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/230"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/231"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/232"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/233"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/234"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/235"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/236"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/238"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/239"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/24"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/240"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/241"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/242"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/243"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/244"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/245"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/246"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/247"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/248"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/249"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/25"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/250"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/252"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/253"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/254"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/255"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/256"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/257"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/258"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/26"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/260"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/261"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/262"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/263"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/264"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/265"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/266"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/267"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/268"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/269"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/27"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/270"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/271"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/272"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/273"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/274"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/275"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/277"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/278"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/279"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/28"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/280"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/281"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/282"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/283"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/284"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/285"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/287"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/288"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/289"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/29"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/290"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/291"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/293"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/294"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/295"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/296"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/297"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/298"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/299"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/3"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/30"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/300"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/301"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/302"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/303"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/304"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/305"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/306"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/307"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/308"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/309"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/31"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/310"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/311"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/312"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/313"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/314"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/315"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/316"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/317"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/318"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/319"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/32"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/320"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/321"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/322"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/323"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/324"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/325"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/326"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/327"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/328"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/329"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/33"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/330"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/331"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/332"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/333"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/334"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/335"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/336"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/337"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/338"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/339"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/34"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/340"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/341"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/342"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/343"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/344"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/345"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/346"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/347"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/35"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/36"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/37"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/38"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/4"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/453"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/454"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/455"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/456"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/457"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/458"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/459"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/460"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/461"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/462"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/463"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/464"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/465"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/466"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/467"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/468"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/469"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/470"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/471"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/472"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/473"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/474"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/475"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/5"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/560"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/561"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/6"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/65"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/66"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/67"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/68"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/69"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/7"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/71"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/72"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/726"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/727"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/73"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/74"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/8"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/823"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/863"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/864"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/865"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/866"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/867"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/868"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/869"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/870"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/871"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/872"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/873"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/874"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/879"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/881"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/882"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/883"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/884"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/885"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/886"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/887"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/890"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/891"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/892"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/894"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/895"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/896"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/897"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/898"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/899"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/9"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/900"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/901"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/902"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/903"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/904"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/905"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/908"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/909"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/910"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/911"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/912"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/913"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/914"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/915"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/916"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/917"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/918"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/919"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/920"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/921"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/922"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/923"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/924"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/925"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/926"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/927"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/928"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/933"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/934"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/935"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.aodn.org.au/def/platform/entity/99"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/096U"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/09AR"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/09SS"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/33OC"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/353L"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/11"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/12"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/14"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/16"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/17"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/23"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/26"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/27"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/30"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/31"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/33"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/35"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/36"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/37"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/38"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/39"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/3A"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/41"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/42"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/43"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/45"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/46"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/64"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/65"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/70"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/72"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/73"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/74"/>
+	<hasConcept xmlns="http://schema.semantic-web.at/ppt/schemeview#" rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/77"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/25"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/platform/entity/726"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/platform/entity/727"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/platform/entity/823"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/11"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/12"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/14"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/16"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/17"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/23"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/26"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/27"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/30"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/31"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/33"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/35"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/36"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/37"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/38"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/39"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/3A"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/41"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/42"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/43"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/45"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/46"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/64"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/65"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/70"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/72"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/73"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/74"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/77"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/61"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/62"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/67"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/6A"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/71"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/75"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/76"/>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-03-27T23:12:59Z</dcterms:modified>
+	<dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2019-04-03</dcterms:issued>
+	<owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Version 3.5</owl:versionInfo>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/elements/1.1/rights">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://purl.org/dc/elements/1.1/rights"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://purl.org/dc/terms/Agent"/>
+	<foaf:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMII_Finney.Kim_Admin</foaf:name>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/terms/created">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/created"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/terms/creator">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/creator"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://purl.org/dc/terms/Agent"/>
+	<foaf:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sebastien-Mancini</foaf:name>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/terms/description">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/description"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/terms/identifier">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/identifier"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/25">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">unmanned autonomous underwater vehicle</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-04-08T00:00:00Z</dcterms:created>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/39"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/74"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L061) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:38Z</dcterms:modified>
+	<skos:definition xml:lang="en">A free-roving platform operating in the water column with propulsion but no human operator on board (e.g. Autosub Glider).</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/35"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#narrower">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#narrower"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/terms/publisher">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/publisher"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://editor.vocabs.ands.org.au/user/eMarine-Information-Infrastructure-eMII">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://purl.org/dc/terms/Agent"/>
+	<foaf:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine-Information-Infrastructure-eMII</foaf:name>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/terms/subject">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/subject"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/terms/title">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/title"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://schema.semantic-web.at/ppt/identifier">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://schema.semantic-web.at/ppt/identifier"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://schema.semantic-web.at/ppt/schemeview#hasConcept">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://schema.semantic-web.at/ppt/schemeview#hasConcept"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/1">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">OOCL Panama</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-12T01:56:12Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien_Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:33Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VRDU8</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Hong Kong January 2015.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9355769</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2008</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/10">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Lady Basten</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-01-05T05:40:47Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-03T00:00:40Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/31"/>
+	<skos:definition xml:lang="en">Research vessel, which was operated by the Australian Institute of Marine Science (AIMS). It was replaced by the Cape Solander at AIMS. It is now known as the Ocean Hunter III.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:7702009</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1978</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/100">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Spirit of Tasmania 2</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-03-27T21:34:55Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VNSZ</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/35"/>
+	<skos:definition xml:lang="en">Passenger/Ro-Ro Cargo ship vessel, which is currently flying the flag of Australia (May 2013)</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9158434</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1998</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/73"/>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/0926/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/101">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Stadacona</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-03-27T22:17:37Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">C6FS9</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">General Cargo ship vessel, which is currently flying the flag of Bahamas (May 2013)</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:8010934</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1984</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/BH1S/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/102">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Wana Bhum</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:39Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">HSB3403</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Thailand (May 2013)</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9308663</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2005</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/103">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Iron Yandi</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:39Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VNVR</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Bulk Carrier vessel, which was flying the flag of Australia. It was renamed the Star Yandi (call sign: C6ZY9) after July 2012. It was disposed of in approximately 2015. </skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9122904</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1996</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/104">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Pacific Sun</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:39Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">9HA2479</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Passenger (Cruise) ship Vessel, which was flying the flag of Malta. It was renamed the Henna after July 2012.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:8314122</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1986</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/105">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Portland</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:52:18Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VNAH</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">General Cargo ship vessel, which is currently flying the flag of Australia (May 2013). It was disposed of in 2016.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:8509117</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1988</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/0956/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/106">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Pacific Celebes</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:49:53Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VRZN9</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">General Cargo ship vessel, which is currently flying the flag of Hong Kong (May 2013). It was disposed of in approximately 2012.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:8126599</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1984</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/HKPB/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/107">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Sea Flyte</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-04T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:40Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VHW5167</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/35"/>
+	<skos:definition xml:lang="en">Passenger ship vessel, which is currently flying the flag of Australia (February, 2009).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9129768</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1995</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/108">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Fantasea Wonder</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-04T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-03-27T21:34:08Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VJQ7467</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/35"/>
+	<skos:definition xml:lang="en">Passenger ship vessel, which is currently flying the flag of Australia (June, 2012).</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1987</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/090C/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/109">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Linnaeus</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-07-01T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-03-27T21:25:14Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VHW6005</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/31"/>
+	<skos:definition xml:lang="en">RV Linnaeus is a small CSIRO research vessel collecting underway bulk SST from its occasional trips within 200 nm from Hillarys Boat Harbour, WA.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/09B1/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/11">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">James Kirby</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-01-05T05:58:46Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-03T00:00:07Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">2189QB</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/31"/>
+	<skos:definition xml:lang="en">Research vessel which is operated by James Cook University (JCU)</skos:definition>
+	<skos:hiddenLabel xml:lang="en">MMSI:503416000</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1971</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/110">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Xutra Bhum</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:33Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">HSB3402</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Thailand (May 2013)</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9308675</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2005</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/111">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Tangaroa</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T04:05:07Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">ZMFR</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/36"/>
+	<skos:definition xml:lang="en">Fishing support vessel, which is currently flying the flag of New Zealand (May 2013)</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9011571</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1991</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/61TN/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/112">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Santo Rocco</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:33Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">LFB13191P</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/36"/>
+	<skos:definition xml:lang="en">Trawler fishing vessel operated by Australian Wild Tuna, which is currently flying the Australian flag (May 2012)</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:8402826</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1984</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/113">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Austral Leader II</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:33Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VHLU</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/36"/>
+	<skos:definition xml:lang="en">Trawler fishing vessel, currently flying the Australian flag (May 2013)</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:7382770</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1975</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/114">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Janas</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:33Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">ZMTW</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/36"/>
+	<skos:definition xml:lang="en">Fishing vessel, currently flying the New Zealand flag (May 2013)</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9057109</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1993</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/115">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Will Watch</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:33Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">E5WW</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/36"/>
+	<skos:definition xml:lang="en">Trawler fishing vessel, currently flying the New Zealand flag (May 2012)</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:7225831</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1973</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/116">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Southern Champion</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T04:04:29Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VHGI</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/36"/>
+	<skos:definition xml:lang="en">Trawler fishing vessel, currently flying the Australian flag (May 2013). It was decommissioned in 2015.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:7351147</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1974</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/09UK/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/117">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Rehua</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:33Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">ZMRE</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/36"/>
+	<skos:definition xml:lang="en">Trawler fishing vessel, currently flying the New Zealand flag (August 2011)</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9147784</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1997</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/118">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Hespérides</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T03:50:56Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">EBBW</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/31"/>
+	<skos:definition xml:lang="en">Research vessel, currently flying the flag of Spain (May 2013)</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:8803563</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1991</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/29HE/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/119">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">ANL Windarra</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-03-27T21:38:27Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">V7LE9</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, currently flying the flag of Marshall Islands (May 2013)</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9324849</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2007</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/MHV4/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/12">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Marion Dufresne</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-01-05T06:00:42Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T03:53:02Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">FNIN</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/31"/>
+	<skos:definition xml:lang="en">Research/survey vessel, currently flying the flag of France.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9050814</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1995</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/35MV/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/120">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Bateman's Marine Park 90m Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T05:22:49Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">BMP090</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Bateman's Marine Park 90m Mooring is operated by SIMS (Sydney Institute of Marine Science) and collects data adjacent to the Bateman's Marine Park. This mooring was decommissioned in September 2015. </skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-36.192,nominal longitude:150.233,nominal depth:90m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/121"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/122"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/123"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/165"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/166"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/177"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/20"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/40"/>
+	<dcterms:valid xml:lang="en">2011-03-30/2015-09-27</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/121">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Bateman's Marine Park 120m Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T05:18:40Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">BMP120</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Bateman's Marine Park 120m Mooring is operated by SIMS (Sydney Institute of Marine Science) and collects data adjacent to the Bateman's Marine Park. This mooring was briefly decommissioned in 2014, but re-deployed shortly afterwards.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-36.213,nominal longitude:150.309,nominal depth:120m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/120"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/122"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/123"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/165"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/166"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/177"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/20"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/40"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/122">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Coffs Harbour 70m Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T05:17:14Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">CH070</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Coffs Harbour 100m Mooring is operated by SIMS (Sydney Institute of Marine Science) and collects data in the Coffs Harbour region.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-30.275,nominal longitude:153.3,nominal depth:70m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/120"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/121"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/123"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/165"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/166"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/177"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/20"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/40"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/123">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Coffs Harbour 100m Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T05:18:40Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">CH100</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Coffs Harbour 100m Mooring is operated by SIMS (Sydney Institute of Marine Science) and collects data in the Coffs Harbour region.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-30.268,nominal longitude:153.397,nominal depth:100m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/120"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/121"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/122"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/165"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/166"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/177"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/20"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/40"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/124">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Capricorn Channel Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T05:59:34Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">GBRCCH</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Capricorn Channel Mooring is operated by AIMS (Australian Institute of Marine Science) and collects data in the Great Barrier Reef region.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-22.40013583,nominal longitude:151.9835005556,nominal depth:87m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/125"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/126"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/127"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/128"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/129"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/130"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/131"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/65"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/125">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Elusive Reef Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T06:30:42Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">GBRELR</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Elusive Reef Mooring is operated by AIMS (Australian Institute of Marine Science) and collects data in the Great Barrier Reef region. This mooring was decommissioned in October 2014.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-21.0169036111,nominal longitude:151.9835005556,nominal depth:300m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/124"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/126"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/127"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/128"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/129"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/130"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/131"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/65"/>
+	<dcterms:valid xml:lang="en">2007-09-15/2014-10-14</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/126">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Heron Island South Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T06:36:32Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">GBRHIS</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Heron Island South Mooring is operated by AIMS (Australian Institute of Marine Science) and collects data in the Great Barrier Reef region.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-23.5002216667,nominal longitude:151.9500819444,nominal depth:48m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/124"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/125"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/127"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/128"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/129"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/130"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/131"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/65"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/127">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Lizard Shelf Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T06:42:47Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">GBRLSH</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Lizard Shelf Mooring is operated by AIMS (Australian Institute of Marine Science) and collects data in the Great Barrier Reef region. This mooring was decommissioned in May 2014.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-14.6836033333,nominal longitude:145.6335044444,nominal depth:24m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/124"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/125"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/126"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/128"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/129"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/130"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/131"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/65"/>
+	<dcterms:valid xml:lang="en">2008-06-14/2014-05-20</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/128">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Lizard Slope Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T06:43:12Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">GBRLSL</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Lizard Slope Mooring is operated by AIMS (Australian Institute of Marine Science) and collects data in the Great Barrier Reef region. This mooring was decommissioned in May 2014.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-14.3334358333,nominal longitude:145.3335055556,nominal depth:360m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/124"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/125"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/126"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/127"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/129"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/130"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/131"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/65"/>
+	<dcterms:valid xml:lang="en">2007-11-03/2014-05-23</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/129">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Myrmidon Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T06:50:27Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">GBRMYR</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Myrmidon Mooring is operated by AIMS (Australian Institute of Marine Science) and collects data in the Great Barrier Reef region.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-18.2661111111,nominal longitude:147.3335058333,nominal depth:200m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/124"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/125"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/126"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/127"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/128"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/130"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/131"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/65"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/13">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Melville</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-01-05T06:01:55Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T03:59:45Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">WECB</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/31"/>
+	<skos:definition xml:lang="en">Research vessel, which was operated by Scripps Oceanography.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1969</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/318M/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/130">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">One Tree East Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T06:59:42Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">GBROTE</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The One Tree East Mooring is operated by AIMS (Australian Institute of Marine Science) and collects data in the Great Barrier Reef region.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-23.4833341667,nominal longitude:152.1667661111,nominal depth:60m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/124"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/125"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/126"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/127"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/128"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/129"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/131"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/65"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/131">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Palm Passage Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T06:59:42Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">GBRPPS</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Palm Passage Mooring is operated by AIMS (Australian Institute of Marine Science) and collects data in the Great Barrier Reef region.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-18.3001725,nominal longitude:147.1502211111,nominal depth:60m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/124"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/125"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/126"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/127"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/128"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/129"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/130"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/65"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/132">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Flat Top Banks Shelf Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T06:34:24Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">ITFFTB</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Flat Top Banks Shelf Mooring is operated by AIMS (Australian Institute of Marine Science) and collects data as part of the Indonesian Thoughflow array.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-12.2834455556,nominal longitude:128.4668363889,nominal depth:103m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/133"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/134"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/135"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/133">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Joseph Bonaparte Gulf Shelf Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T06:37:41Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">ITFJBG</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Joseph Bonaparte Gulf Shelf Mooring is operated by AIMS (Australian Institute of Marine Science) and collects data as part of the Indonesian Thoughflow array.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-13.6001363889,nominal longitude:128.9666875,nominal depth:59m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/132"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/134"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/135"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/134">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Margaret Harries Banks Shelf Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T06:43:25Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">ITFMHB</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Margaret Harries Banks Shelf Mooring is operated by AIMS (Australian Institute of Marine Science) and collects data as part of the Indonesian Thoughflow array.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-11,nominal longitude:128,nominal depth:145m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/132"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/133"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/135"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/135">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Timor South Shelf Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T06:43:25Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">ITFTIS</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Timor South Shelf Mooring is operated by AIMS (Australian Institute of Marine Science) and collects data as part of the Indonesian Thoughflow array.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-9.8166730556,nominal longitude:127.5500552778,nominal depth:465m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/132"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/133"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/134"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/136">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Jervis Bay Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:31Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">JB070</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Jervis Bay Mooring is operated by UNSW (University of New South Wales), ADFA (Australian Defence Force Academy) and collects data in Jervis Bay. This mooring was decommissioned in October 2009.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-35.083,nominal longitude:150.85,nominal depth:70m</skos:scopeNote>
+	<dcterms:valid xml:lang="en">2009-07-28/2009-10-07</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/137">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Kimberley 50m Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T06:42:09Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">KIM050</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Kimberley 50m Mooring is operated by AIMS (Australian Institute of Marine Science) and collects data as part of the Kimberley array. This mooring was decommissioned in August 2014.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-16.3879,nominal longitude:121.58813,nominal depth:50m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/138"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/139"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/140"/>
+	<dcterms:valid xml:lang="en">2011-10-21/2014-08-19</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/138">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Kimberley 100m Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T06:41:45Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">KIM100</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Kimberley 100m Mooring is operated by AIMS (Australian Institute of Marine Science) and collects data as part of the Kimberley array. This mooring was decommissioned in August 2014.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-15.5347,nominal longitude:121.3038,nominal depth:100m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/137"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/139"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/140"/>
+	<dcterms:valid xml:lang="en">2012-02-01/2014-08-24</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/139">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Kimberley 200m Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T06:42:00Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">KIM200</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Kimberley 200m Mooring is operated by AIMS (Australian Institute of Marine Science) and collects data as part of the Kimberley array. This mooring was decommissioned in August 2014.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-15.67976,nominal longitude:121.24307,nominal depth:200m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/137"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/138"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/140"/>
+	<dcterms:valid xml:lang="en">2012-02-02/2014-08-27</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/14">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Mirai</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-01-05T06:08:07Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T04:00:09Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">JNSR</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/31"/>
+	<skos:definition xml:lang="en">Research vessel, currently flying the flag of Japan.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:6919423</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1991</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/49NZ/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/140">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Kimberley 400m Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T06:42:09Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">KIM400</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Kimberley 400m Mooring is operated by AIMS (Australian Institute of Marine Science) and collects data as part of the Kimberley array. This mooring was decommissioned in August 2014. </skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-15.22097,nominal longitude:121.11471,nominal depth:400m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/137"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/138"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/139"/>
+	<dcterms:valid xml:lang="en">2012-02-03/2014-08-25</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/141">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Darwin National Reference Station Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T06:37:53Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">NRSDAR</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Darwin National Reference Station Mooring is operated by AIMS (Australian Institute of Marine Science) and collects data from coastal ocean waters off Darwin.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-12.3334013889,nominal longitude:130.6835363889,nominal depth:20m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/142"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/143"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/145"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/146"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/147"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/148"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/149"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/150"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/151"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/152"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/66"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/67"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/68"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/142">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Esperance National Reference Station ADCP Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T06:33:12Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">NRSESP-ADCP</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">ADCP mooring located at the Esperance National Reference Station. This mooring is operated by CSIRO. This mooring was decommissioned in December 2013.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-33.9166666667,nominal longitude:121.85,nominal depth:52m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/141"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/143"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/145"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/146"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/147"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/148"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/149"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/150"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/151"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/152"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/66"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/67"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/68"/>
+	<dcterms:valid xml:lang="en">2011-08-18/2013-12-05</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/143">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Esperance National Reference Station Sub-surface Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T01:45:23Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">NRSESP-SubSurface</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/43"/>
+	<skos:definition xml:lang="en">Sub-surface mooring located at the Esperance National Reference Station. This mooring is operated by CSIRO. This mooring was decommissioned in December 2013.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-33.9333333333,nominal longitude:121.85,nominal depth:51m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/141"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/142"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/146"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/147"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/149"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/150"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/66"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/68"/>
+	<dcterms:valid xml:lang="en">2011-08-18/2013-12-05</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/144">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Kangaroo Island National Reference Station Acidification Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T06:40:50Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">NRSKAI-CO2</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">Acidification mooring located at the Kangaroo Island National Reference Station. This mooring is operated by SARDI (South Australian Research and Development Institute).</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-35.836,nominal longitude:136.448,nominal depth:110m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/69"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/898"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/899"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/145">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Kangaroo Island National Reference Station Sub-surface Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T01:45:42Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">NRSKAI-SubSurface</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/43"/>
+	<skos:definition xml:lang="en">Sub-surface mooring located at the Kangaroo Island National Reference Station. This mooring is operated by SARDI (South Australian Research and Development Institute).</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-35.836,nominal longitude:136.448,nominal depth:110m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/141"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/142"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/146"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/147"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/149"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/150"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/66"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/68"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/146">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Ningaloo Reef National Reference Station Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T06:52:40Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">NRSNIN</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Ningaloo Reef National Reference Station Mooring is operated by AIMS (Australian Institute of Marine Science) and collects data from coastal ocean waters around Nigaloo Reef. This mooring was decommissioned in August 2014.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-21.868,nominal longitude:113.934,nominal depth:55m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/141"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/142"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/143"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/145"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/147"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/148"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/149"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/150"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/151"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/152"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/66"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/67"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/68"/>
+	<dcterms:valid xml:lang="en">2010-08-02/2014-08-13</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/147">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">North Stradbroke Island National Reference Station ADCP Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T06:54:39Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">ADCP mooring located at the North Stradbroke Island National Reference Station. This mooring is operated by CSIRO.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-27.3392283333,nominal longitude:153.5617733333,nominal depth:60m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/141"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/142"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/143"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/145"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/146"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/148"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/149"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/150"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/151"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/152"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/66"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/67"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/68"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/148">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">North Stradbroke Island National Reference Station Sub-surface Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T01:46:23Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/43"/>
+	<skos:definition xml:lang="en">Sub-surface mooring located at the North Stradbroke Island National Reference Station. This mooring is operated by CSIRO.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-27.3834263889,nominal longitude:153.5668925,nominal depth:60m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/141"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/142"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/146"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/147"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/149"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/150"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/66"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/68"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/149">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">North Stradbroke Island National Reference Station Surface Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T06:56:31Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">NRSNSI</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">Surface mooring located at the North Stradbroke Island National Reference Station. This mooring is operated by CSIRO.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-27.3409883333,nominal longitude:153.5611833333,nominal depth:60m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/141"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/142"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/143"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/145"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/146"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/147"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/148"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/150"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/151"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/152"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/66"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/67"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/68"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/15">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">San Tongariro</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-01-19T06:04:46Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-02T23:34:30Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">ZMA3180</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/36"/>
+	<skos:definition xml:lang="en">Trawler fishing vessel, currently flying the flag of New Zealand.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9149914</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1997</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/150">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Rottnest Island National Reference Station ADCP Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T01:46:49Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">NRSROT-ADCP</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">ADCP mooring located at the Rottnest Island National Reference Station. This mooring is operated by CSIRO.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-32,nominal longitude:115.4,nominal depth:50m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/141"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/142"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/143"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/145"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/146"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/147"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/148"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/149"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/151"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/152"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/66"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/67"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/68"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/151">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Rottnest Island National Reference Station Sub-surface Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T01:46:37Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/43"/>
+	<skos:definition xml:lang="en">Sub-surface mooring located at the Rottnest Island National Reference Station. This mooring is operated by CSIRO.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-32,nominal longitude:115.4166666667,nominal depth:48m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/141"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/142"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/146"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/147"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/149"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/150"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/66"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/68"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/152">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Yongala National Reference Station Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T01:46:49Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">NRSYON</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Yongala National Reference Station Mooring is operated by AIMS (Australian Institute of Marine Science) and collects data near the Yongala Wreck, out from Cape Bowling Green in the central Great Barrier Reef.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-19.3001019444,nominal longitude:147.6167258333,nominal depth:28m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/141"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/142"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/146"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/147"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/149"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/150"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/66"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/68"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/153">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Port Hacking 100m Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:36Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">PH100</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Port Hacking 100m Mooring is operated by SIMS (Sydney Institute of Marine Science) and collects data from coastal ocean waters off Port Hacking.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-34.12031,nominal longitude:151.22437,nominal depth:110m</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/154">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Pilbara 50m Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T01:35:13Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">PIL050</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Pilbara 50m Mooring is operated by AIMS (Australian Institute of Marine Science)  and collects data as part of the Pilbara array. This mooring was decommissioned in August 2014. </skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-20.05467,nominal longitude:116.41615,nominal depth:50m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/155"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/156"/>
+	<dcterms:valid xml:lang="en">2012-02-21/2014-08-16</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/155">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Pilbara 100m Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T07:00:22Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">PIL100</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Pilbara 100m Mooring is operated by AIMS (Australian Institute of Marine Science) and collects data as part of the Pilbara array. This mooring was decommissioned in August 2014.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-19.69437,nominal longitude:116.11155,nominal depth:100m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/154"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/156"/>
+	<dcterms:valid xml:lang="en">2012-02-20/2014-08-16</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/156">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Pilbara 200m Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T01:35:13Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">PIL200</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Pilbara 200m Mooring is operated by AIMS (Australian Institute of Marine Science) and collects data as part of the Pilbara array. This mooring was decommissioned in August 2014.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-19.43557,nominal longitude:115.91535,nominal depth:200m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/154"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/155"/>
+	<dcterms:valid xml:lang="en">2012-02-20/2014-08-16</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/157">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Deep Slope Mooring (M1)</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T06:04:33Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">SAM1DS</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Deep Slope Mooring (M1) is operated by SARDI (South Australian Research and Development Institute), and was a South Australian regional mooring. This mooring was decommissioned in June 2009.  </skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-36.516,nominal longitude:136.244,nominal depth:525m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/163"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/158"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/159"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/160"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/161"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/162"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/164"/>
+	<dcterms:valid xml:lang="en">2008-12-11/2009-06-04</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/158">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Cabbage Patch Mooring (M2)</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T05:51:30Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">SAM2CP</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Cabbage Patch Mooring (M2) is operated by SARDI (South Australian Research and Development Institute), and is a South Australian regional mooring. This mooring was decommissioned in March 2010.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-35.268,nominal longitude:135.684,nominal depth:99m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/163"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/157"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/159"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/160"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/161"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/162"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/164"/>
+	<dcterms:valid xml:lang="en">2008-10-20/2010-03-17</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/159">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Mid-Slope Mooring (M3)</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T06:50:04Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">SAM3MS</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Mid-Slope Mooring (M3) is operated by SARDI (South Australian Research and Development Institute), and was a South Australian regional mooring. This mooring was decommissioned in June 2013. </skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-36.1459,nominal longitude:135.904,nominal depth:175m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/163"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/157"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/158"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/160"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/161"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/162"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/164"/>
+	<dcterms:valid xml:lang="en">2011-02-22/2013-06-30</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/160">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Canyon Mooring (M4)</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T05:54:02Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">SAM4CY</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Canyon Mooring (M4) is operated by SARDI (South Australian Research and Development Institute), and is a South Australian regional mooring. This mooring was decommissioned in March 2010.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-36.52,nominal longitude:136.856,nominal depth:119m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/163"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/157"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/158"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/159"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/161"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/162"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/164"/>
+	<dcterms:valid xml:lang="en">2009-02-05/2010-03-16</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/161">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Coffin Bay Mooring (M5)</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T06:00:09Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">SAM5CB</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Coffin Bay Mooring (M5) is operated by SARDI (South Australian Research and Development Institute), and is one of five South Australian regional moorings.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-34.928,nominal longitude:135.01,nominal depth:99m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/163"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/157"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/158"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/159"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/160"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/162"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/164"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/162">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Investigator Strait Mooring (M6)</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T06:36:52Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">SAM6IS</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Investigator Strait Mooring (M6) is operated by SARDI (South Australian Research and Development Institute), and is a South Australian regional mooring. This mooring was decommissioned in June 2009.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-35.5,nominal longitude:136.6,nominal depth:82m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/163"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/157"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/158"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/159"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/160"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/161"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/164"/>
+	<dcterms:valid xml:lang="en">2009-02-05/2009-06-02</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/164">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Spencer Gulf Mouth Mooring (M8)</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T06:50:04Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">SAM8SG</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Spencer Gulf Mooring (M8) is operated by SARDI (South Australian Research and Development Institute), and is one of five South Australian regional moorings.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-35.25,nominal longitude:136.69,nominal depth:47m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/163"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/157"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/158"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/159"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/160"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/161"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/162"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/165">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Sydney 100m Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T05:43:51Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">SYD100</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Sydney 100m Mooring is operated by SIMS (Sydney Institute of Marine Science) and collects data in the Sydney region.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-33.943,nominal longitude:151.382,nominal depth:100m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/120"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/121"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/122"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/123"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/166"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/177"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/20"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/40"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/166">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Sydney 140m Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-15T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T05:43:51Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">SYD140</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Sydney 140m Mooring is operated by SIMS (Sydney Institute of Marine Science) and collects data in the Sydney region.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-33.994,nominal longitude:151.459,nominal depth:140m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/120"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/121"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/122"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/123"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/165"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/177"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/20"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/40"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/167">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Canyon 200m Head Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-21T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T05:53:01Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">WACA20</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Canyon 200m Head Mooring is operated by CSIRO and collects data in the Perth Canyon region.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-31.9833333333,nominal longitude:115.2333333333,nominal depth:200m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/168"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/169"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/168">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Canyon 500m North Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-21T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T05:53:12Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">WACANO</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Canyon 500m North Mooring is operated by CSIRO and collects data in the Perth Canyon region. This mooring was decommissioned in July 2010.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-31.922,nominal longitude:114.993,nominal depth:500m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/167"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/169"/>
+	<dcterms:valid xml:lang="en">2010-01-22/2010-07-20</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/169">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Canyon 500m South Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-21T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T05:53:12Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">WACASO</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Canyon 500m South Mooring is operated by CSIRO and collects data in the Perth Canyon region. This mooring was decommissioned in March 2014. </skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-31.0500555556,nominal longitude:115.0669333333,nominal depth:500m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/167"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/168"/>
+	<dcterms:valid xml:lang="en">2010-01-22/2014-03-07</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/17">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Glaucus</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-20T23:09:01Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-02T23:59:43Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/31"/>
+	<skos:definition xml:lang="en">Research vessel, which was operated by the Department of Environment, Climate Change and Water (DECCW), NSW.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1989</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/170">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Two Rocks 50m Shelf Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-21T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T05:50:38Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">WATR05</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Two Rocks 50m Shelf Mooring is operated by CSIRO and collects data in the Two Rocks region. This mooring was decommissioned in May 2013.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-31.6168333333,nominal longitude:115.2335416667,nominal depth:50m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/171"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/172"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/173"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/174"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/903"/>
+	<dcterms:valid xml:lang="en">2009-07-07/2013-05-27</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/171">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Two Rocks 100m Shelf Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-21T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T05:49:03Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">WATR10</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Two Rocks 100m Shelf Mooring is operated by CSIRO and collects data in the Two Rocks region.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-31.6335555556,nominal longitude:115.1835416667,nominal depth:100m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/170"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/172"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/173"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/174"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/903"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/172">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Two Rocks 150m Shelf Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-21T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T05:49:36Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">WATR15</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Two Rocks 150m Shelf Mooring is operated by CSIRO and collects data in the Two Rocks region. This mooring was decommissioned in October 2013.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-31.6835,nominal longitude:115.1166666667,nominal depth:150m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/170"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/171"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/173"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/174"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/903"/>
+	<dcterms:valid xml:lang="en">2009-07-07/2013-10-03</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/173">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Two Rocks 200m Shelf Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-21T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T05:50:07Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">WATR20</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Two Rocks 200m Shelf Mooring is operated by CSIRO and collects data in the Two Rocks region.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-31.7167111111,nominal longitude:115.0168888889,nominal depth:200m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/170"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/171"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/172"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/174"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/903"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/174">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Two Rocks 500m Shelf Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-21T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T05:50:38Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">WATR50</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Two Rocks 500m Shelf Mooring is operated by CSIRO and collects data in the Two Rocks region.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-31.7667305556,nominal longitude:114.9335,nominal depth:500m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/170"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/171"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/172"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/173"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/903"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/175">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">South-East Queensland 200m Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-21T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-19T01:40:34Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">SEQ200</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The South-East Queensland 200m Mooring is operated by CSIRO and collects data as part of the East Australian Current (EAC) array. This mooring was decommissioned in June 2013.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-27.332,nominal longitude:153.877,nominal depth:400m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/176"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/188"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/189"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/190"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/191"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/192"/>
+	<dcterms:valid xml:lang="en">2012-03-25/2013-06-06</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/176">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">South-East Queensland 400m Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-21T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-19T01:40:53Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">SEQ400</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The South-East Queensland 400m Mooring is operated by CSIRO and collects data as part of the East Australian Current (EAC) array. This mooring was decommissioned in June 2013.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-27.34,nominal longitude:153.775,nominal depth:200m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/175"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/188"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/189"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/190"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/191"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/192"/>
+	<dcterms:valid xml:lang="en">2012-03-24/2013-06-06</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/177">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Ocean Reference Station Sydney Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-21T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T05:22:49Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">ORS065</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Ocean Reference Station Sydney Mooring is operated by Sydney Water and collects data in the Sydney region.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-33.8975,nominal longitude:151.3153,nominal depth:65m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/120"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/121"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/122"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/123"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/165"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/166"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/20"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/40"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/178">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Perth Canyon, WA Passive Acoustic Observatory</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-21T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-17T04:55:46Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">PAPCA</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/43"/>
+	<skos:definition xml:lang="en">The Perth Canyon, WA Passive Acoustic Observatory, is a series of moorings operated by Curtin University which collect data in the Perth Canyon region. This observatory was decommissioned in October 2017.  </skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-31.892,nominal longitude:114.939,nominal depth:455m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/179"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/180"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/5"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/904"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/905"/>
+	<dcterms:valid xml:lang="en">2008-02-26/2017-10-14</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/179">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Portland, VIC Passive Acoustic Observatory</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-21T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-17T04:56:17Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">PAPOR</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/43"/>
+	<skos:definition xml:lang="en">The Portland, VIC Passive Acoustic Observatory, is a series of moorings operated by Curtin University which collect data in the Portland region. This observatory was decommissioned early in 2018. </skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-38.545,nominal longitude:141.241,nominal depth:168m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/178"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/180"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/5"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/904"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/905"/>
+	<dcterms:valid xml:lang="en">2009-05-06/2018-03-31</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/18">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Bombora</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-20T23:11:37Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-02T23:59:03Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">SY907</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/31"/>
+	<skos:definition xml:lang="en">Research vessel which is operated by the Office of Environment and Heritage (OEH), NSW. </skos:definition>
+	<skos:hiddenLabel xml:lang="en">MMSI:503041620 </skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2009</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/180">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Tuncurry, NSW Passive Acoustic Observatory</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-21T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-17T04:56:17Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">PATUN</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/43"/>
+	<skos:definition xml:lang="en">The Tuncurry, NSW Passive Acoustic Observatory, is a series of moorings operated by Curtin University which collect data in the Tuncurry/Forster region. This observatory was decommissioned in early 2018.  </skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-32.31,nominal longitude:152.927,nominal depth:161m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/178"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/179"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/5"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/904"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/905"/>
+	<dcterms:valid xml:lang="en">2010-02-10/2018-03-31</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/181">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Southern ocean Flux Station mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-23T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T05:42:59Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">SOFS</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Southern ocean Flux Station Mooring is operated by the Australian Bureau of Meteorology (BOM), which collect data in the Sub-Antarctic Zone.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-46.77187,nominal longitude:141.98687,nominal depth:0m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/187"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/32"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/911"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/187">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Sub-Antarctic Zone Sediment Trap Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-23T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T05:42:59Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">SAZOTS</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Sub-Antarctic Zone Sediment Trap Mooring is operated by CSIRO, which collect data in the Sub-Antarctic Zone.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-54.0,nominal longitude:140.0,nominal depth:3640m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/181"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/32"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/911"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/188">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">East Australian Current 1 Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-23T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T05:40:52Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">EAC1</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The East Australian Current 1 Mooring is operated by CSIRO, and collects data in the East Australian Current. The array that this mooring was part of was decommissioned in August 2013, and a newly configured array (with new moorings) was redeployed in May 2015. </skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-27.31,nominal longitude:153.98,nominal depth:1649m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/175"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/176"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/189"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/190"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/191"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/192"/>
+	<dcterms:valid xml:lang="en">2012-04-19/2013-08-28</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/189">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">East Australian Current 2 Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-23T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T05:41:02Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">EAC2</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The East Australian Current 2 Mooring is operated by CSIRO, and collects data in the East Australian Current. The array that this mooring was part of was decommissioned in August 2013, and a newly configured array (with new moorings) was redeployed in May 2015. </skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-27.3,nominal longitude:154.03,nominal depth:2257m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/175"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/176"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/188"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/190"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/191"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/192"/>
+	<dcterms:valid xml:lang="en">2012-04-19/2013-08-28</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/19">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Yolla</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-03-27T00:50:06Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-03T00:02:19Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/31"/>
+	<skos:definition xml:lang="en">Research vessel, which is operated by Deakin University.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">Unique Identifier:MSV12324 </skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2012</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/190">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">East Australian Current 3 Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-23T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T05:41:09Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">EAC3</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The East Australian Current 3 Mooring is operated by CSIRO, and collects data in the East Australian Current. The array that this mooring was part of was decommissioned in August 2013, and a newly configured array (with new moorings) was redeployed in May 2015. </skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-27.26,nominal longitude:154.29,nominal depth:4393m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/175"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/176"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/188"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/189"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/191"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/192"/>
+	<dcterms:valid xml:lang="en">2012-04-19/2013-08-28</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/191">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">East Australian Current 4 Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-23T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T05:41:18Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">EAC4</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The East Australian Current 4 Mooring is operated by CSIRO, and collects data in the East Australian Current. The array that this mooring was part of was decommissioned in August 2013, and a newly configured array (with new moorings) was redeployed in May 2015. </skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-27.21,nominal longitude:154.65,nominal depth:4815m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/175"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/176"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/188"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/189"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/190"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/192"/>
+	<dcterms:valid xml:lang="en">2012-04-19/2013-08-28</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/192">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">East Australian Current 5 Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-23T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T05:41:25Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">EAC5</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The East Australian Current 5 Mooring is operated by CSIRO, and collects data in the East Australian Current. The array that this mooring was part of was decommissioned in August 2013, and a newly configured array (with new moorings) was redeployed in May 2015. </skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-27.1,nominal longitude:155.3,nominal depth:4707m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/175"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/176"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/188"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/189"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/190"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/191"/>
+	<dcterms:valid xml:lang="en">2012-04-19/2013-08-28</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/193">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Ombai Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-23T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T06:59:27Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">ITFOMB</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Ombai Mooring is operated by CSIRO, and collects data in the Indonesian Throughflow. This mooring was decommissioned in October 2015. 
+        </skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-8.52983,nominal longitude:125.0885,nominal depth:3251m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/194"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/195"/>
+	<dcterms:valid xml:lang="en">2011-06-09/2015-10-22</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/194">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Timor North Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-23T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T05:44:47Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">ITFTIN</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Timor North Mooring is operated by CSIRO, and collects data in the Indonesian Throughflow. This mooring was decommissioned in April 2014. 
+        </skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-8.855,nominal longitude:127.198,nominal depth:1114m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/193"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/195"/>
+	<dcterms:valid xml:lang="en">2011-06-09/2014-04-17</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/195">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Timor Sill Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-23T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T05:44:47Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">ITFTSL</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Timor Sill Mooring is operated by CSIRO, and collects data in the Indonesian Throughflow. This mooring was decommissioned in October 2015.
+        </skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-9.2757,nominal longitude:127.3557,nominal depth:3300m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/193"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/194"/>
+	<dcterms:valid xml:lang="en">2011-05-26/2015-10-26</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/196">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Polynya1 Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-23T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T01:40:14Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">POLYNYA1</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Polynya1 mooring is operated by CSIRO, and collects data near the Adelie Land coast, in the Southern Ocean. This mooring was decommissioned in January 2015.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-66.19767,nominal longitude:143.46867,nominal depth:600m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/197"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/198"/>
+	<dcterms:valid xml:lang="en">2011-01-10/2015-01-17</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/197">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Polynya2 Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-23T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T01:40:25Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">POLYNYA2</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Polynya2 mooring is operated by CSIRO, and collects data near the Adelie Land coast, in the Southern Ocean. This mooring was decommissioned in January 2015.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-66.20372,nominal longitude:143.20683,nominal depth:600m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/196"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/198"/>
+	<dcterms:valid xml:lang="en">2011-01-10/2015-01-17</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/198">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Polynya3 Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-23T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T01:40:25Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">POLYNYA3</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Polynya3 mooring is operated by CSIRO, and collects data near the Adelie Land coast, in the Southern Ocean. The mooring is trapped in sea ice, and considered irretrievable in 2015.
+        </skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-66.14992,nominal longitude:143.01283,nominal depth:560m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/196"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/197"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/199">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Joana Bonita</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-27T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:37:34Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">3EFY6</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">General Cargo ship vessel. It was called the Joana Bonita from 1988 until April 2002. It is now called the Xuan De Men (Panama, June 2010). It was disposed of in approximately 2010.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:7813597</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1979</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/PAJB/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/2">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Beagle Gulf Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-07T03:18:13Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Natalia_Atkins"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-02T23:38:20Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">DARBGF</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Beagle Gulf Mooring is operated by AIMS (Australian Institute of Marine Science) and collects data which complements the National Reference Station in Darwin Harbour.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-12.1075,nominal longitude:130.58725,nominal depth:29.6m</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/20">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Bateman's Marine Park 70m Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-06-15T02:48:05Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T05:19:13Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">BMP070</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">It is one of two moorings deployed near Narooma, southern NSW, to capture the variability of the shelf waters, poleward of the East Australian Current (EAC) separation point. This mooring replaces the former 90m mooring, and was enabled through co-investment from Bega Valley Shire Council.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-36.1897,nominal longitude:150.1893,nominal depth:70m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/120"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/121"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/122"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/123"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/165"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/166"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/177"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/40"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/200">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">M-Sagar</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-27T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:42Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">3FHA9</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel. It was called the d M-Sagar between Aug 2010 and Aug 2012, and is now called the Meratus Gorontalo (Indonesia, Feb 2013).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9202895</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1999</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/201">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Medontario</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-27T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:43:16Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">5BDC2</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Cyprus (May 2013).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9437115</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2008</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/CYAF/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/202">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Forum Samoa II</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-27T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-07T06:51:37Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">5WDC</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">General Cargo ship vessel. It was called the Forum Samoa II from 2001 until June 2010. It was then shortly called the Opal Harmony, then Southern Moana, and is now known as Capitaine Fearn (July, 2015).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9210713</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2001</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/WSFS/"/>
+	<owl:sameAs rdf:resource="http://vocab.aodn.org.au/def/platform/entity/908"/>
+	<owl:sameAs rdf:resource="http://vocab.aodn.org.au/def/platform/entity/16"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/203">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Montreal Senator</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-27T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:42Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">9MCN6</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel. It was called the Montreal Senator between June 1998 and January 2006, it is now called the Strait Mas (Indonesia, January 2009). It was disposed of in 2016. </skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:8705424</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1987</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/204">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Swan River Bridge</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-27T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:57:54Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">9V8218</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Singapore (May 2013).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9550395</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2010</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/SISR/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/205">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Australia Star</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-27T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:42Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">9VBZ</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel. It was called the Australia Star from 1978 until Feb 1989, and March 1992 until May 1994. It was disposed of in 2001 (Sea Express).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:7636676</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1978</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/206">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Tower Bridge</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-27T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:43Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">9VMI6</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Singapore (May 2013). It was disposed of in approximately 2010.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:8505989</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1985</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/207">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Anro Asia</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-27T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T04:09:01Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">9VUU</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which flew the flag of Singapore. It was disposed of in 1997.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:7631456</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1978</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/SIAD/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/208">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">New Zealand Star</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-27T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:43Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">9VWM</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which flew the flag of Singapore. It was disposed of in 1998.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:7113301</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1971</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/209">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Capitaine Tasman</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-27T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-03-27T21:43:07Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">A3BN5</skos:altLabel>
+	<skos:altLabel xml:lang="en">P3CV9</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">General Cargo ship vessel. It was called the Capitaine Tasman from March 2002 until April 2010. This ship's callsign was P3CV9 in 2002. It is now called Ual Coburg (Cyprus, August 2009).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9210725</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">callsign:A3BN5 (P3CV9 in 2002), built:2002</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/TNCT/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/21">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Camden Sound 50m Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-06-15T02:52:46Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T05:51:57Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">CAM050</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Camden 50m mooring (platform code CAM050) was deployed in 2014 for a short time in the Kimberley region replacing the former Kimberley and Pilbara arrays. It was decommissioned in 2015.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-14.8502,nominal longitude:123.8026,nominal depth:50m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/22"/>
+	<dcterms:valid xml:lang="en">2014-08-28/2015-07-28</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/210">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Fua Kavenga</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-31T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:42Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">A3CA</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Ro-ro cargo ship vessel. It was called the Fua Kavenga from 1979 until May 2002. It is now called the Ocean Glory (Comoros, May 2013). It was disposed of in approximately 2011.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:7820538</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1979</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/211">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Southern Moana</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-28T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:55:53Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">A3CG3</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">General Cargo ship vessel. It was called the Southern Moana from Dec 2001 until may 2011. It is now called the Red Rock (Indonesia, October 2010).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9197026</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2000</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/TNSM/"/>
+	<owl:sameAs rdf:resource="http://vocab.aodn.org.au/def/platform/entity/916"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/212">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Nedlloyd Nelson</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-28T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:41Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">A8AI6</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel. It was called the P&amp;O Nedlloyd Nelson from July 2002 until May 2004. It is now called the Hansa Nordburg (Liberia, January 2008).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9236212</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2002</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/213">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">MSC Hobart</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-28T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:39:21Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">A8AK3</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel. This ship was also called the MSC Hobart from Oct 2004 until May 2007. It has been named as such again from July 2007, and is currently flying the flag of Liberia (May 2013).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9077288</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1994</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/54BO/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/214">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">CMA CGM Charcot</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-28T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-19T04:57:52Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">A8HE4</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel. It was called the CMA CGA Charcot from Nov 2007 until Aug 2011. It is now called the Euro Max (Liberia, October 2012).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9232773</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2002</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/54CR/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/215">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">CMA CGM Mimosa</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-28T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-19T04:58:25Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">A8IF2</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Liberia (May 2013).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9314961</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2006</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/54MI/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/216">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">CMA CGM Melbourne</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-28T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:16:46Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">A8IG9</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel. It was called the CMA CGM Melbourne from 2006 until Aug 2008. It is now called the Westertal (Liberia, March 2008).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9316347</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2006</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/54ME/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/217">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Passat Spring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-28T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:51:23Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">A8JY8</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Liberia (May 2013).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9316359</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2006</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/54PS/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/218">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">CMA CGM Auckland</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-28T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-19T05:06:09Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">A8KD7</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Liberia (May 2013).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9344564</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2006</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/54A6/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/219">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Ital Ottima</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-28T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:42Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">A8LN3</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Liberia (May 2013).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9337262</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2007</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/22">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Camden Sound 100m Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-06-15T02:56:39Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T05:51:57Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">CAM100</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Camden 100m mooring (platform code CAM100) was deployed in 2014 for a short time in the Kimberley region replacing the former Kimberley and Pilbara arrays. It was decommissioned in 2015.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-14.31475,nominal longitude:123.5954,nominal depth:100m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/21"/>
+	<dcterms:valid xml:lang="en">2014-08-29/2015-07-28</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/220">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Buxlink</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-28T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T04:52:01Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">A8SW3</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Liberia (May 2013).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9235816</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2002</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/54CQ/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/221">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">AS Cypria</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-28T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:40Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">A8UY4</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Liberia (May 2013).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9315812</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2006</skos:scopeNote>
+	<owl:sameAs rdf:resource="http://vocab.aodn.org.au/def/platform/entity/926"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/222">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">MSC Federica</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-28T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:39Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">C4LV</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">A vessel, which flew the flag of Cyprus. It was disposed of in approximately 2010.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:7347512</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1974</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/223">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Brisbane Star</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-31T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T04:51:39Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">C6LY4</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel. It was called the Brisbane Star from July 1993 until Jan 1998. It was disposed of in 2002.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:7516371</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1978</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/BHBS/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/224">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">P&amp;O Nedlloyd Adelaide</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-31T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:39Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">C6RJ6</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel. It was called the P&amp;O Nedlloyd Adelaide from Oct 2000 until Jan 2006. It is now called the Sky Interest (Hong Kong, 2006). It was disposed of in 2007.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:7428380</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1977</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/225">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">CMA CGM Utrillo</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-28T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:39Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">C6VL6</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which flew the flag of Bahamas. It is now called the CMA CGM Matisse (Cyprus, January 2009).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9192428</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1999</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/226">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Stadt Weimar</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-28T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:56:44Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">DCHO</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel. This ship was also called the Stadt Weimar from 2006 until March 2011. It has been named as such again from March 2012, and is currently flying the flag of Germany (July 2012).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9320051</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2006</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/06WM/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/227">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Canberra Express</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-28T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:24:38Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">DFCW2</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Germany (May 2013).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9224049</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2000</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/06CZ/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/228">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Wellington Express {DFCX2}</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-28T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T06:00:48Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">DFCX2</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Germany (May 2013). The ship's callsign was VSUA5 from 2006 until May 2007.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9224051</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">callsign:DFCX2 (VSUA5, 2006-05/2007), built:2001</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/06SD/"/>
+	<owl:sameAs rdf:resource="http://vocab.aodn.org.au/def/platform/entity/285"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/229">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Adelaide Express</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-28T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:40Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">DHSN</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel. It was called the Adelaide Express form Feb 2006 until July 2009. It is now called the Classica (Antigua &amp; Barbuda, April 2009). It was disposed of in 2016. </skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9143245</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1998</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/23">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Northwest Sanderling</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-06-15T06:36:06Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string"> eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-03-27T06:45:14Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VNVZ</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">LNG tanker vessel, which is currently flying the flag of Australia (June 2017).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:8608872</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1989</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/09WX/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/230">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Contship Action</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-28T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-03-27T21:44:23Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">DLHV</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, managed by Contship Containerlines, and was sold in 2003. It was disposed of in approximately 2012. </skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9122215</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1996</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/06AT/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/231">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">P&amp;O Nedlloyd Encounter</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-28T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-19T05:39:30Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">DPGZ</skos:altLabel>
+	<skos:altLabel xml:lang="en">ELZZ4</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel. It was called the P&amp;O Nedlloyd Encounter from April 2002 until Jan 2006.  The ship's callsign was ELZZ4 from 2003 until October 2004. It is now called the Santa Rebecca (Germany, January 2008).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9227302</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">callsign:DPGZ (ELZZ4, 2003-2004) ,built:2002</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/06EC/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/232">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Bay Bridge</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-28T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:33Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">ELES7</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Liberia (May 2013). It was disposed of in approximately 2009.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:8413203</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1985</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/233">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">P&amp;O Nedlloyd Otago</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-28T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:48:58Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">ELJP4</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel. It was called the P&amp;O Nedlloyd Otago from Aug 1999 until July 2000. It is now called the Provider (Liberia, March 2006). It was disposed of in approximately 2009.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:7807263</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1978</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/54OT/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/234">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Pacific Triangle</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-28T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:33Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">ELXS8</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Bulk Carrier vessel, which is currently flying the flag of Liberia (May 2013).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9189158</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2000</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/235">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">P&amp;O Nedlloyd Salerno</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-31T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:33Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">ELYE9</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel. It was called the P&amp;O Nedlloyd Salerno from July 2000 until June 2002. It is now called the Isolde (Liberia, Feb 2008).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9187875</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2000</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/236">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">MSC New Plymouth</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-31T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:33Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">ELZT9</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel. It was called the MSC New Plymouth from January 2002 until January 2004. It is now called the Hansa Aelesund (Liberia, May 2013).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9221061</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2001</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/238">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Melbourne Star</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-29T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:33Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">GOVL</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of UK (June 2011). It was disposed of in 2003.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:7108162</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1971</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/239">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Encounter Bay</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-29T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-03-27T21:46:55Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">GYRW</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which was flying the flag of UK. It was disposed of in 1999.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:6818461</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1969</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/74B8/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/24">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Tonsberg</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-06-16T02:18:54Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string"> Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-06-16T02:20:43Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">HA2066</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Vehicle carrier vessel, currently flying the flag of Malta (February 2017).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9515383</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2011</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/240">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Flinders Bay</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-29T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:31:57Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">GYSA</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which was flying the flag of UK. It was disposed of in 1996.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:6822541</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1969</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/74FG/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/241">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Botany Bay</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-29T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T04:51:16Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">GYSE</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which was flying the flag of UK. It was disposed of in 1999.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:6907016</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1969</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/74B7/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/242">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Discovery Bay</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-31T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:30:39Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">GYXG</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which was flying the flag of Saint Vincent &amp; Grenadines. It was disposed of in 1998.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:6901426</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1969</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/74D9/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/243">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">America Star</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-29T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T04:08:12Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">GZKA</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which was flying the flag of UK. It was disposed of in 2003.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:7052909</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1971</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/BHAJ/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/244">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">MSC Didem</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-29T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:32Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">H8VZ</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Panama (May 2013).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:8517891</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1987</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/245">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Safmarine Meru</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-29T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-19T05:41:25Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">9V6535</skos:altLabel>
+	<skos:altLabel xml:lang="en">MNDC9</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Singapore (April 2012). It was disposed of in 2016.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9311696</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">callsign:9V6535 (MNDC9 prior to Feb, 2011); built:2006</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/SIW6/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/246">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Wellington Express {MWSD3}</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-31T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T06:00:31Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">MWSD3</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel. It was called the Wellington Express from 1996 until August 2002. It is now caled the Troy Y (Moldova, August 2012).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">built:9130901</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">commissioned:1996</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/74WB/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/247">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Polar Star</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-29T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:51:59Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">NBTM</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Icebreaker vessel, which is currently flying the flag of the US (May 2013).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:7367471</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1976</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/32PZ/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/248">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">SA Sederberg</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-29T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:32Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">ONAT</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which was flying the flag of Belgium (2003). It was disposed of in approximately 2008.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:7423031</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1978</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/249">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Maersk Constantia</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-29T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-03-27T22:03:03Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">ONAV</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel. It was called the Maersk Constantia from May 2001 until June 2008. It was disposed of in 2008.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:7422207</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1979</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/11AE/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/25">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">ANL Waratah</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-06-16T02:21:09Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-03-27T21:37:58Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">A8IY2</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, currently flying the flag of Liberia (March 2017).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9326794</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2005</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/5438/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/250">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Lowlands Prosperity</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-29T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:38:20Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">ONDB</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Bulk Carrier vessel. It was called the Lowlands Prosperity from Aug 2004 until Jan 2012. It is now called the John Oldendorff (Liberia, September 2011).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9225005</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2000</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/11LY/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/252">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Contship Ambition</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-29T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:32Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">P3GU7</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel. It was called the CONTSHIP Ambition from 1996 until Dec 2002. It is now called the Pisti (Panama, April 2008).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9122203</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1996</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/253">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Bartok</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-31T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:32Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">P3ZB3</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">General cargo ship vessel. It was called the Bartok from 1990 until 1995. It is now called the Crown Pearl (Panama, April 2010). It was disposed of in approximately 2012.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:8702850</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1990</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/254">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">P&amp;O Nedlloyd Jakarta</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-30T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:48:28Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">PDHU</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel. It was called the P&amp;O Nedlloyd Jakarta from 1998 until Feb 2006. It is now called the Maersk Penang (Netherlands, November 2010).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9168192</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1998</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/64NW/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/255">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">P&amp;O Nedlloyd Sydney</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-30T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:49:20Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">PDHY</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel. It was called the P&amp;O Nedlloyd Sydney from 1998 until Feb 2006. It is now called the Maersk Pembroke (Netherlands, January 2011).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9168180</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1998</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/64NX/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/256">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Nedlloyd Raleigh Bay</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-30T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:46:01Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">PHKG</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel. It was called the Raleigh Bay from Aug 1994 to Oct 1996. It is now called the Jupiter (Tuvalu, December 2008). It was disposed of in approximately 2012.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:8308719</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1985</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/64RB/"/>
+	<owl:sameAs rdf:resource="http://vocab.aodn.org.au/def/platform/entity/257"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/257">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">P&amp;O Nedlloyd Brisbane</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-30T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:31Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">PHKG</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel. It was called the P&amp;O Nedlloyd Brisbane from Jan 1997 to Jan 2006. It is now called the Jupiter (Tuvalu, December 2008). It was disposed of in approximately 2012. </skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:8308719</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1985</skos:scopeNote>
+	<owl:sameAs rdf:resource="http://vocab.aodn.org.au/def/platform/entity/256"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/258">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Maersk Aberdeen</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-31T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:31Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">S6BD</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Containter ship vessel, which is flying the flag of Hong Kong (May, 2013).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9175793</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1999</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/26">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">ANL Whyalla</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-06-16T02:22:27Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-06-16T02:23:33Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">9VEN5</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel which was known as the ANL Whyalla from 2009 until 2015. It is now known as the SCT Vietnam.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9295359</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2005</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/260">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Meridian</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-30T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:31Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">UUYY</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Training Ship vessel, which was flying the flag of USSR. It was disposed of in 1984.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:5232696</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1962</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/261">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">ANL Progress</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-31T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:31Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">V20D7</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Containter ship vessel. It was called the ANL Progress from July 2003 until May 2005. It is now called the Meratus Batam (Indonesia, May 2013).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9131814</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1996</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/262">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Ranginui</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-31T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:52:54Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">V2AE5</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">General Cargo ship vessel. It was called the Ranginui from August 1994 until November 1999. It is now called the Aylin (Turkey, May 2013).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:8603535</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1984</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/AGRI/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/263">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Baltrum Trader</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-30T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:31Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">V2AP6</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel. It was called the Baltrum Trader (which callsign V2AP6) from Jan 2000 until May 2007. It is again called the Baltrum Trader (callsign A8ZP9), flying the flag of Liberia (April, 2007).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9138317</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1999</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/264">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Florence</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-30T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:32:24Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">V2BF1</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel. It was called the Florence from Oct 2005 until May 2012. It is now called the Damai Sejahtera li (Indonesia, Oct 2010).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9085601</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1995</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/AGFL/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/265">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Vega Gotland</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-30T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:58:55Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">V2BP4</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Antigua &amp; Barbuda (May 2013).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9336347</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2006</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/AGVG/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/266">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Rangitata</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-31T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:53:10Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">V2GB</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Cargo ship vessel. It was called the Rangitata from February 1992 until August 1998. It is now called the Emma (Antigua &amp; Barbuda, May 2013).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:8509014</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1985</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/AGRG/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/267">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Karin Knorr</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-31T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:37:52Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">V2HX</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">General Cargo ship vessel. It was called the Karin from October 1990 until 1998. It is now called the Melody li (Panama, May 2013). It was disposed of in approximately 2009.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:6523107</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1965</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/AGKK/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/268">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Iron Dampier</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-03T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:35:18Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">V2LM</skos:altLabel>
+	<skos:altLabel xml:lang="en">VNGZ</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Cargo ship vessel. It was called the Iron Dampier from May 1992 until April 1998. The ship's callsign was VNGZ from 1992 until September 1996. It was disposed of in 2009.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:7906942</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">callsign:V2LM (VNGZ from 1992-1996), built:1981</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/09DA/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/269">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Anro Australia</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-30T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-03-27T21:39:03Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VJBQ</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Ro-ro Cargo ship vessel. It was called the Anro Australia from 1977 until June 1997. It was then called the Kevat (Saint Vincent &amp; Grenadines). It was disposed of in 1997.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:7619410</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1977</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/09AH/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/27">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Island Chief</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-06-16T02:23:54Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-06-16T02:25:45Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VRRB</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Hong Kong (December 2016)</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:8810449</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1989</skos:scopeNote>
+	<owl:sameAs rdf:resource="http://vocab.aodn.org.au/def/platform/entity/282"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/270">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Iron Newcastle</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-03T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-03-27T21:50:24Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VJDI</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Bulk carrier ship vessel. It was called the Iron Newcastle from 1985 until June 1999. It is now called the Camriz (Panama, Aug 2007). It was disposed of in approximately 2010. </skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:8412443</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1985</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/09NC/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/271">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Iron Kembla</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-03T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:35:53Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VJDK</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Bulk carrier ship vessel. It was called the Iron Kembla from 1986 until May 2005. It was then called the Merit Land (Panama). It was disposed of in approximately 2011.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:8412455</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1986</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/09IK/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/272">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Iron Pacific</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-03T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:36:09Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VJDP</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Bulk carrier ship vessel. It was called the Iron Pacific from 1986 until 1998. It was then called the Berge Pacific (Norway). It was disposed of in approximately 2011.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:8412675</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1986</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/09PC/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/273">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Franklin</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-30T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T03:50:24Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VJJF</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/31"/>
+	<skos:definition xml:lang="en">Research ship vessel, which was flying the flag of Australia. It was decommissioned in 2002.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:8301797</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1985</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/09FA/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/274">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Australian Progress</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-03T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:36Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VMAP</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Bulk carrier ship vessel. It was called the Australian Progress from 1977 until March 1991. It was then called Treasure Sea (Panama). It was disposed of in 1992.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:7408823</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1977</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/275">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Iron Flinders</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-03T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:35:36Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VNGL</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">General cargo ship vessel. It was called the Iron Flinders from February 1991 until May 1999. It is now called the India Express (Panama, January 2008). It was disposed of in approximately 2013. </skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:8407199</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1986</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/09FD/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/277">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Australian Enterprise</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-03T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T04:09:23Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VNVT</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel. It was called the Australian Enterprise from January 1997 until 2001. It was most recently called the ANL Explorer. It was disposed of in approximately 2009.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:8506098</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1985</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/09AU/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/278">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Contship Borealis</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-30T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:30:11Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VQEN2</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel. It was called the Contship Borealis from 2002 until Aug 2005. It is now called the Glasgow Express (Germany, January 2008).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9232589</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2002</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/74HZ/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/279">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Contship Australis</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-30T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:29:39Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VQEN3</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel. It was called the Contship Australis from 2002 until July 2005. It is now called the Dublin Express (Germany, October 2010).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9232577</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2002</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/74HX/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/28">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Kweichow</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-06-16T03:37:03Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-06-16T03:38:03Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VRAE2</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Cargo ship vessel, which is currently flying the flag of Hong Kong (November 2015).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9070694</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1994</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/280">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Coral Chief</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-30T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:35Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VROC</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Hong Kong (May 2013).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:8809191</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1989</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/281">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Papuan Chief</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-30T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:51:00Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VRRC</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Hong Kong (May 2013).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:8901705</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1991</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/HKPC/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/282">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Kokopo Chief</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-30T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-06-16T02:25:45Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VRRD</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Hong Kong (May 2013).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:8907412</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1990</skos:scopeNote>
+	<owl:sameAs rdf:resource="http://vocab.aodn.org.au/def/platform/entity/27"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/283">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">P&amp;O Nedlloyd Napier</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-30T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:35Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VRSC</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which was flying the flag of Hong Kong. It was called the P&amp;O Nedlloyd Napier from Aug 1998. It was disposed of in approximately 2000.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:7020401</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1970</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/284">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">P&amp;O Nedlloyd Wellington</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-30T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:35Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VSOP5</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel. It was called the P&amp;O Nedlloyd Wellington from June 2004 until Nov 2005. It is now called the Cs Star (UK, September 2011).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9020338</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1993</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/285">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">TMM Tabasco</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-30T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:35Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VSUA5</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel. It was called the Tmm Tabasco from 2000 until August 2005. It is now called the Wellington Express {DFCX2} (Germany, May 2013)</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9224051</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">commissioned:2001</skos:scopeNote>
+	<owl:sameAs rdf:resource="http://vocab.aodn.org.au/def/platform/entity/228"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/287">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Canmar Dynasty</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-30T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:35Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VSXC4</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel. It was called the Canmar Dynasty from May 2003 until July 2005. It is now called the Sydney Express (UK, Feb 2012).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9062984</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1994</skos:scopeNote>
+	<owl:sameAs rdf:resource="http://vocab.aodn.org.au/def/platform/entity/288"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/288">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Sydney Express</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-30T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:35Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VSXC4</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of the UK (Feb, 2012).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9062984</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1994</skos:scopeNote>
+	<owl:sameAs rdf:resource="http://vocab.aodn.org.au/def/platform/entity/287"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/289">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Nimos</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-03T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:35Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">ZCSL</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel. It was called the Nimos from 1977 until December 1990. It was disposed of in approximately 2011.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:7640005</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1977</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/29">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Philadelphia</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-06-16T03:38:33Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-06-16T03:40:46Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">A8CN8</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Liberia (August 2015).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9232101</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2002</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/290">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Contship Aurora</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-30T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:29:18Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">ZIZP9</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel. It was called the Contship Aurora from 2002 until 2005. It is currently called the Liverpool Express (Germany, May 2013).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9232565</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2002</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/74I3/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/291">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Act 6</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-31T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T04:07:43Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">GOVN</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel. It was called the Act 6 from 1972 until January 1992. It was disposed of in 2003.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:7226275</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1972</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/74AS/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/293">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Slocum Glider</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-04T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:34Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/27"/>
+	<skos:definition xml:lang="en">The Slocum glider is 1.8 m long, 21.3 cm in diameter and weighs 52 kg.  Manufactured by Webb Research Corporation, the glider is designed to operate in coastal waters of up to 200 m deep where high maneuverability is needed.  Moving at an average forward velocity of 25 - 40 cm/s the glider travels in a sawtooth pattern through the water navigating its way to a series of pre-programmed waypoints using GPS and altimeter measurements.  Operating on C cell alkaline batteries, typical deployments can range up to 500 km with a duration of approximately 30 days. </skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/294">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Seaglider UW</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-04T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:34Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/27"/>
+	<skos:definition xml:lang="en">These Seagliders are 1.8m long, 30cm in diameter and weigh 52kg. Manufactured by the Seaglider Fabrication Center at the University of Washington, the gliders are designed to operate in the open ocean in depth up to 1000m.  Moving at an average forward velocity of 25 cm/s, Seagliders travel more slowly, alternately diving and climbing along slanting glide paths.  The gliders obtain GPS navigation fixes when they surface, which they use to glide through a sequence of programmed targets.  As they are deployed in the open ocean, Seagliders have a very large range sufficient to transit entire ocean basins and can be deployed for periods of up to 6 months. </skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/295">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">1KA Seaglider</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-04T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:34Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/27"/>
+	<skos:definition xml:lang="en">These Seagliders are 1.8-2m long, 30cm in diameter and weigh 52kg. Manufactured by iROBOT, they are designed to operate in the open ocean in depth up to 1000m.  Moving at an average forward velocity of 25 cm/s, Seagliders travel more slowly, alternately diving and climbing along slanting glide paths.  The gliders obtain GPS navigation fixes when they surface, which they use to glide through a sequence of programmed targets.  As they are deployed in the open ocean, Seagliders have a very large range sufficient to transit entire ocean basins and can be deployed for periods of up to 6 months. </skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/296">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">NEMO Argo Float</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-07T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:34Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/46"/>
+	<skos:definition xml:lang="en">Navigating European Marine Observer (NEMO) Argo floats are manufactured by Optimare Sensorsystems AG. They are 2m (not including antenna) long, and weigh 30kg. Their maximum operational depth is 2000m, with a life time of 5 years / 150 profiles.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">manufacturer:Optimare Sensorysystems AG</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/297">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">NINJA Argo Float with SBE</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-07T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:34Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/46"/>
+	<skos:definition xml:lang="en">New profilINg float of JApan (NINJA) Argo floats are manufactured by the Tsurumi Seiki Co. (TSK). They are approx. 2420mm long, and weigh approx 32kg. Their maximum operational depth is 2000m. This float has a SBE conductivity sensor.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">manufacturer:Tsurumi Seiki Co.</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/298">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">NAVIS Argo Float with Iridium antenna</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-07T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:34Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/46"/>
+	<skos:definition xml:lang="en">Navis Argo floats are manufactured by Sea-Bird Electronics Inc. They are 159cm long, and weigh about 17kg. Their maximum operational depth is 2000m, with a life time of 300 CTD profiles. This float uses an alternative to the usual Systeme Argos location and data transmission system, and uses positions from the Global Positioning System (GPS) and data communication using the Iridium satellites. As of 2010, 250 floats have been deployed with Iridium antennas.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">manufacturer:Sea-Bird Electronics Inc.</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/299">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">ARVOR Argo Float</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-07T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:34Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/46"/>
+	<skos:definition xml:lang="en">Arvor Argo floats were originally manufactured by Kannad. The scientific instrumentation division for deep-sea oceanography was purchased by NKE Instrumentation on January 1st, 2009. They are 120cm long, and weight about 20kg. Their maximum operational depth is 2100m, with a life time of 4 years / 150+ cycles.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">manufacturer:NKE Instrumentation</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/3">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">RTM Wakmatha</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-07T03:26:45Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Natalia_Atkins"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:52:37Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">9V2768</skos:altLabel>
+	<skos:altLabel xml:lang="en">MVTW4</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Bulk Carrier vessel, which is currently flying the flag of Singapore (October 2014). This ship previously flew the UK flag, with a corresponding callsign of MVTW4.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9341914</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">callsign:9V2768 (MVTW4 prior to 2014); built:2007</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/747X/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/30">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Portugal</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-06-16T03:39:39Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-06-16T03:40:54Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">D5IH5</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Liberia (December 2015).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9147083</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1998</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/300">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">SOLO Argo Float</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-07T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:36Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/46"/>
+	<skos:definition xml:lang="en">SOLO Argo floats are manufactured by Scripps Institution of Oceanography, UC San Diego. They are 26 inches long, and weigh 18.6kg. Their maximum operational depth is 2300m, with a life time of 8.5 years / 300 profiles.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">manufacturer:Scripps Institution of Oceanography</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/301">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">SOLO Argo Float with Iridium antenna</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-07T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:36Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/46"/>
+	<skos:definition xml:lang="en">SOLO Argo floats are manufactured by Scripps Institution of Oceanography, UC San Diego. They are 26 inches long, and weigh 18.6kg. Their maximum operational depth is 2300m, with a life time of 8.5 years / 300 profiles. This float uses an alternative to the usual Systeme Argos location and data transmission system, and uses positions from the Global Positioning System (GPS) and data communication using the Iridium satellites. As of 2010, 250 floats have been deployed with Iridium antennas.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">manufacturer:Scripps Institution of Oceanography</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/302">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">SOLO-II Argo Float with Iridium antenna</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-07T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:36Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/46"/>
+	<skos:definition xml:lang="en">MRV Systems has licensed the intellectual property from Scripps Institution of Oceanography, UC San Diego to manufacture SOLO-II floats. They are 26 inches long, and weigh 18.6kg. Their maximum operational depth is 2300m, with a life time of 8.5 years / 300 profiles.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">manufacturer:MRV Systems</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/303">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">PALACE R1 Argo Float</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-07T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:36Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/46"/>
+	<skos:definition xml:lang="en">Profiling Autonomous Lagrangian Circulation Explorer (PALACE) R1 Argo floats were manufactured by Webb Research Corporation. They have been replaced by the APEX model.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">manufacturer:Webb Research</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/304">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">APEX Argo Float</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-07T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:36Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/46"/>
+	<skos:definition xml:lang="en">Autonomous Profiling EXplorer (APEX) Argo floats are manufactured by Teledyne Webb Research. The are 130 cm (not including antenna) long, and weigh 26kg. Their maximum operational depth is 2000m, with a life time of 4 years / 150 profiles.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">manufacturer:Teledyne Webb Research</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/305">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">APEX Argo Float with Iridium antenna</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-07T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:36Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/46"/>
+	<skos:definition xml:lang="en">Autonomous Profiling EXplorer (APEX) Argo floats are manufactured by Teledyne Webb Research. The are 130 cm (not including antenna) long, and weigh 26kg. Their maximum operational depth is 2000m, with a life time of 4 years / 150 profiles. This float uses an alternative to the usual Systeme Argos location and data transmission system, and uses positions from the Global Positioning System (GPS) and data communication using the Iridium satellites. As of 2010, 250 floats have been deployed with Iridium antennas.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">manufacturer:Teledyne Webb Research</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/306">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">APEX Argo Float with APF8 controller board</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-07T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:36Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/46"/>
+	<skos:definition xml:lang="en">Autonomous Profiling EXplorer (APEX) Argo floats are manufactured by Teledyne Webb Research. The are 130 cm (not including antenna) long, and weigh 26kg. Their maximum operational depth is 2000m, with a life time of 4 years / 150 profiles. This float uses an APF8 controller board.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">manufacturer:Teledyne Webb Research</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/307">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">PROVOR Argo Float</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-07-04T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:36Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/46"/>
+	<skos:definition xml:lang="en">Martec and MetOcean Data Systems Ltd. merged in 2001, with Martec creating PROVOR floats for the French and European markets, and MetOcean will manufacture PROVOR floats for the markets in North America and outside of Europe. PROVOR CTS3 has been designed by IFREMER and MARTEC in industrial partnership. and are manufactured by NKE Instrumentation. The scientific instrumentation division for deep-sea oceanography of Kannad was purchased by NKE Instrumentation on January 1st, 2009. They are 170cm long, and weight about 34kg. Their maximum operational depth is 2000m, with a life time of 4/4.5 years / 170 cycles.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">manufacturer:Martec/Metocean/NKE Instrumentation/Kannad</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/308">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Lizard Island Base Station</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-13T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T06:31:11Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">Lizard_Island</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/14"/>
+	<skos:definition xml:lang="en">The infrastructure consists of a base station mounted on the workshop of the Lizard Island Research Station (LIRS), two sensor poles that create the on-reef network and four sensor floats on which the sensors are attached.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/309"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/310"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/311"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/312"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/313"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/314"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/309">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Lizard Island Relay Pole 1</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-13T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T06:30:59Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">LIZRP1</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/16"/>
+	<skos:definition xml:lang="en">A 6m galvanized pole has been deployed in the western part of the lagoon. It has no sensors attached to it.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/308"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/310"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/311"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/312"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/313"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/314"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/31">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Salome</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-06-16T03:41:29Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-06-16T03:43:18Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">9V9112</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Vehicle carrier vessel, currently flying the flag of Singapore (April 2015).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9515412</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2011</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/310">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Lizard Island Relay Pole 2</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-13T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T06:31:11Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">LIZRP2</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/16"/>
+	<skos:definition xml:lang="en">A 6m galvanized pole has been deployed in the eastern part of the lagoon in behind Seabird Islet. The Relay Pole has three functions. The first is to propagate the wireless network through which the buoys talk and so it forms part of the network backbone talking directly to Relay-Pole 1. The second function is that a vaisala WXT520 weather station is mounted on the top and so this pole provides above water met observations. These include air temperature, humidity, air pressure, wind speed and direction and rainfall. The third function is that a sensor string is attached to the pole, the sensor string runs through a channel in Seabird Islet across the exposed seaward reef flat to the reef crest and then down the reef slope to around 20m. This gives a profile down the reef slope and gives readings of the water coming onto the reef complex. The pole has two Campbell Scientific loggers (one for the weather station, one for the sensors), spread-spectrum radio and 2.4/5 GHz 802.11 wireless for communicating with the base station (located at the workshop near the Research Station). The sensor string as of August 2010 has a SeaBird SBE37 at the end of the sensor string (around 230m out from the pole), and two SeaBird SBE39's located at teh reef crest and down at the start of the reef slope.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/308"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/309"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/311"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/312"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/313"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/314"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/311">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Lizard Island Sensor Float 1</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-13T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-17T02:24:43Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">LIZSF1</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/41"/>
+	<skos:definition xml:lang="en">A round 1.4m yellow buoy has been deployed in the southern part of the main lagoon of Lizard Island to the south-east of Palfrey Island. The buoy is configured as a sensor-float with a Campbell Scientific logger, spread-spectrum radio and 2.4/5 GHz 802.11 wireless for communicating with the base station (located at the workshop near the Research Station) a surface mounted (60cm under the water surface) thermistor and an inductive modem to support a range of inductive sensors, initially this will be a SeaBird SBE39 measuring temperature and pressure (depth) and a SeaBird SBE37 measuring conductivity (salinity), temperature and depth. As of August 2010 the inductive sensors are just located in the area around the buoy, it is intended at a later date to re-position these southwards on the external reef slope to give a profile of water outside the lagoon. This buoy was decommissioned in March 2018. </skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/308"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/309"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/310"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/312"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/313"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/314"/>
+	<dcterms:valid xml:lang="en">2010-08-15/2014-04-04</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/312">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Lizard Island Sensor Float 2</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-13T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-17T02:26:10Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">LIZSF2</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/41"/>
+	<skos:definition xml:lang="en">A round 1.4m yellow buoy has been deployed in the southern part of the main lagoon of Lizard Island to the east of Palfrey Island. The buoy is configured as a sensor-float with a Campbell Scientific logger, spread-spectrum radio and 2.4/5 GHz 802.11 wireless for communicating with the base station (located at the workshop near the Research Station) a surface mounted (60cm under the water surface) thermistor and an inductive modem to support a range of inductive sensors, initially this will be a SeaBird SBE39 measuring temperature and pressure (depth) and a SeaBird SBE37 measuring conductivity (salinity), temperature and depth. As of August 2010 the inductive sensors are located along a 30m cable that runs north into the main lagoon with a SBE39 located at the base of the buoy and the SBE37 at the end of the sensor run. This buoy was decommissioned in March 2018.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/308"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/309"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/310"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/311"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/313"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/314"/>
+	<dcterms:valid xml:lang="en">2010-08-13/2016-11-14</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/313">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Lizard Island Sensor Float 3</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-13T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T05:46:19Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">LIZSF3</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/41"/>
+	<skos:definition xml:lang="en">A round 1.4m yellow buoy has been deployed in the eastern part of the main lagoon of Lizard Island. The buoy is configured as a sensor-float with a Campbell Scientific logger, spread-spectrum radio and 2.4/5 GHz 802.11 wireless for communicating with the base station (located at the workshop near the Research Station) a surface mounted (60cm under the water surface) thermistor and an inductive modem to support a range of inductive sensors, initially this will be a SeaBird SBE39 measuring temperature and pressure (depth). As of August 2010 the inductive sensors are located along a 30m cable that runs north into the main lagoon with a SBE39 located at the end of the sensor run.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/308"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/309"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/310"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/311"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/312"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/314"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/314">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Lizard Island Sensor Float 4</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-13T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T05:46:43Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">LIZSF4</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/41"/>
+	<skos:definition xml:lang="en">A round 1.4m yellow buoy has been deployed in the western part of the main lagoon of Lizard Island to the south of the research station. The buoy is configured as a sensor-float with a Campbell Scientific logger, spread-spectrum radio and 2.4/5 GHz 802.11 wireless for communicating with the base station (located at the workshop near the Research Station) a surface mounted (60cm under the water surface) thermistor and an inductive modem to support a range of inductive sensors, initially this will be a SeaBird SBE39 measuring temperature and pressure (depth) and a SeaBird SBE37 measuring conductivity (salinity), temperature and pressure (depth). As of August 2010 the inductive sensors are located along a 50m cable that runs north into the main lagoon with a SBE39 located at the base of the buoy and the 37 at the end of the sensor run.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/308"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/309"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/310"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/311"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/312"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/313"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/315">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Orpheus Island Base Station</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-13T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T06:33:06Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">Orpheus_Island</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/14"/>
+	<skos:definition xml:lang="en">The infrastructure consists of a base station located on an existing mast at the Orpheus Island Research Station run by James Cook University, two sensor-floats or buoys - one located in Pioneer Bay off the Research Station and one in Little Pioneer Bay and three Relay / Sensor Poles - two located on the reef flat on the north-west point of Orpheus Island and one located on the southern point of near-by Pelorus Island.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/316"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/317"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/318"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/319"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/320"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/316">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Orpheus Island Relay Pole 1</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-13T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-01-15T00:10:42Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">OIRP1</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/16"/>
+	<skos:definition xml:lang="en">A 6m steel self supporting pole was erected on the southern side of Pelorus Island in the channel between Pelorus Island and Orpheus Island. The pole provides network connectivity for the other Relay Poles located on the northen edge of Orpheus Island (RP2 and RP3) as well as a back-haul link to the mainland using a nextG connection. The pole has an array of sensors on it including two MEA thermistors located 50m and 100m away from the pole on a transect from the pole into the deep water of the channel. The pole also has a SeaBird SBE39 (temp + pressure) located around 100m from teh pole and a SBE37 (conductivity, temperature and pressure) located approximatly 200m from teh pole in the deep waters of the channels. The pole was decommissioned in July 2018.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/315"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/317"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/318"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/319"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/320"/>
+	<dcterms:valid xml:lang="en">2009-12-18/2017-09-11</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/317">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Orpheus Island Relay Pole 2</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-13T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-01-15T00:12:23Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">OIRP2</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/16"/>
+	<skos:definition xml:lang="en">A 6m steel self supporting pole was erected on the northern side of Orpehus Island in the channel between Pelorus Island and Orpheus Island. The pole is set up as per RP1 with two MEA thermistors located at 50m and 100m from the pole and an SBE39 located 100m from the pole and an SBE37 located 200m from the pole in the deeper water. This pole was decommissioned in July 2018.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/315"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/316"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/318"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/319"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/320"/>
+	<dcterms:valid xml:lang="en">2009-11-08/2017-09-11</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/318">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Orpheus Island Relay Pole 3</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-13T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-01-15T00:13:52Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">OIRP3</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/16"/>
+	<skos:definition xml:lang="en">A 6m steel self supporting pole was erected on the north/west side of Orpehus Island in the channel between Pelorus Island and Orpheus Island but positioned to face more towards the ocean and just on teh entrance to the channel. RP3 on the seaward side of Orpheus Island is set up the same as RP1 and RP2 although as of early 2010 only the two MEA thermistors at 50 and 100m are installed, the SBE37 and SBE39 wil be instaled later in 2010. A vaisala WTX520 weather station is installed on this pole. This pole was decommissioned in July 2018. </skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/315"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/316"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/317"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/319"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/320"/>
+	<dcterms:valid xml:lang="en">2009-11-08/2017-09-11</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/319">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Orpheus Island Sensor Float 1</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-13T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T05:47:37Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">OISF1</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/41"/>
+	<skos:definition xml:lang="en">A round 1.4m yellow buoy has been deployed in Little Pioneer Bay, Orpheus Island, just off the research station in the central part of the Great Barrier Reef. The buoy is configured as a sensor-float with a Campbell Scientific logger, a spread-spectrum radio for communicating with the base station (located near the Research Station) a surface mounted (60cm under the water surface) thermistor and an inductive modem to support a range of inductive sensors, initially this will be a SeaBird SBE39 measuring temperature and pressure (depth). The float is moored at the entrance to Little Pioneer Bay, just deep of the reef front and will be used to measure the water entering the bay with particular interest in warm water pushing up into the bay. The data will support work being done in the bay by James Cook University researchers.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/315"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/316"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/317"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/318"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/320"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/32">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Pulse Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-06-26T23:19:01Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T05:42:52Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">PULSE</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Pulse mooring is operated by CSIRO, and measures biogeochemical properties of the Southern Ocean. It was first deployed in October 2008. This mooring was decommissioned in April 2016.  </skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-46.312,nominal longitude: 140.673,nominal depth:515m. This general concept replaces previous deployment specific concepts (Pulse 5 'light', Pulse 5 'heavy', Pulse 6, Pulse 7, Pulse 8, Pulse 9 and Pulse 10) previously created.</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/181"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/187"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/911"/>
+	<dcterms:valid xml:lang="en">2009-09-28/2016-04-03</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/320">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Orpheus Island Sensor Float 2</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-13T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T05:48:14Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">OISF2</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/41"/>
+	<skos:definition xml:lang="en">A round 1.4m yellow buoy has been deployed in Little Pioneer Bay, Orpheus Island, just off the research station in the central part of the Great Barrier Reef. The buoy is configured as a sensor-float with a Campbell Scientific logger, a spread-spectrum radio for communicating with the base station (located near the Research Station) a surface mounted (60cm under the water surface) thermistor and an inductive modem to support a range of inductive sensors, initialy this will be a SeaBird SBE39 measuring temperature and pressure (depth). The float is moored at the entrance to Little Pioneer Bay, just deep of the reef front and will be used to measure the water entering the bay with particular interest in warm water pushing up into the bay. The data will support work being done in the bay by James Cook University researchers.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/315"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/316"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/317"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/318"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/319"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/321">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Rib Reef Sensor Float 1</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-13T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-04-05T06:37:02Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">RIBSF1</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/41"/>
+	<skos:definition xml:lang="en">The infrastructure consists of a single 1300 mm buoy located off the north (front) of the reef. The buoy has an Inductive Modem (IM) line that extends from the buoy to the bottom and then along the bottom for around 50 m and then rises to flotation located 9 m below the surface. Instruments are located on this riser to give a profile through the water column. The station is designed to measure temperature of the water column at the front of the reef and in particular to detect upwelling and other events where warmer bottom water is pushed across the shelf onto the reefs. This not only indicates processes operating across the shelf but also conditions when coral bleaching may be more common. The buoy was decommissioned in July 2017.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<dcterms:valid xml:lang="en">2011-12-14/2017-07-19</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/322">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Myrmidon Reef Base Station</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-14T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T05:46:56Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">Myrmidon_Reef</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/14"/>
+	<skos:definition xml:lang="en">The infrastructure consists of a base station mounted on the existing reef communications tower and a single buoy which carries the actual sensors.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/323"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/323">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Myrmidon Reef Sensor Float 1</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-14T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T05:46:56Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">MYRSF1</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/41"/>
+	<skos:definition xml:lang="en">In February 2011 Cyclone 'Yasi' damaged the existing AIMS weather station and so this buoy was deployed with both AIMS weather station sensors and sensors for the IMOS funded GBROOS project. In December 2011, a replacement buoy was deployed with the above water sensors being the existing AIMS weather station units and the in-water sensors being provided under the IMOS funded GBROOS project. This resulted in a data gap between the cyclone in February 2011 and the buoy being deployed in December 2011. It is antcipated that the AIMS weather station will be restored in late 2012 in which case the above water sensors will transition back to the AIMS tower with the in-water sensors remaining as part of the IMOS funded work. This buoy was decommissioned in 2015.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/322"/>
+	<dcterms:valid xml:lang="en">2011-05-03/2015-09-08</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/324">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Davies Reef Base Station</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-14T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T05:36:20Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">Davies_Reef</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/14"/>
+	<skos:definition xml:lang="en">The infrastructure consists of a base station mounted on the existing reef communications tower, using the Telstra nextG service, and 5 buoys which carry the actual sensors. The Davies Reef Base Station performs two functions. The first is to act as a collection point for the sensor network platforms deployed within the reef and to in turn send the data back to the AIMS Data Centre. The second is as a platform for sensors with current sensors including two underwater PAR sensors and a still camera. The base station is co-located with the AIMS Automatic Weather Station (vaisala WXT520) on the Davies Reef Tower in order to optimise the use of power and communications infrastructure.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/325"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/326"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/327"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/328"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/329"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/325">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Davies Reef Sensor Float 1</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-14T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-17T02:29:00Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">DAVSF1</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/41"/>
+	<skos:definition xml:lang="en">A round 1.4m yellow buoy has been deployed in the Davies Reef lagoon as part of the sensor network infrastructure at Davies Reef in the central Great Barrier Reef off Townsville, Australia. The buoy is configured as a sensor-float with a Campbell Scientific logger, a spread-spectrum radio for communicating with the on-reef wireless network, a SeaBird Inductive modem and initially a surface mounted (30cm under the water surface) thermistor and bottom mounted SeaBird SBE39 (temperature and pressure). This buoy was decommissioned in March 2018. </skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/324"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/326"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/327"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/328"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/329"/>
+	<dcterms:valid xml:lang="en">2009-12-09/2017-07-28</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/326">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Davies Reef Sensor Float 2</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-14T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T05:35:01Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">DAVSF2</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/41"/>
+	<skos:definition xml:lang="en">A round 1.4m yellow buoy has been deployed in the Davies Reef lagoon as part of the sensor network infrastructure at Davies Reef in the central Great Barrier Reef off Townsville, Australia. The buoy is configured as a sensor-float with a Campbell Scientific logger, a spread-spectrum radio for communicating with the on-reef wireless network, a SeaBird Inductive modem and initially a surface mounted (30cm under the water surface) thermistor and bottom mounted SeaBird SBE39 (temperature and pressure). The buoy was decommissioned in 2011.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/324"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/325"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/327"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/328"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/329"/>
+	<dcterms:valid xml:lang="en">2009-12-09/2011-12-31</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/327">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Davies Reef Sensor Float 3</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-14T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T05:35:44Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">DAVSF3</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/41"/>
+	<skos:definition xml:lang="en">A round 1.4m yellow buoy has been deployed in the Davies Reef lagoon as part of the sensor network infrastructure at Davies Reef in the central Great Barrier Reef off Townsville, Australia. The buoy is configured as a sensor-float with a Campbell Scientific logger, a spread-spectrum radio for communicating with the on-reef wireless network, a SeaBird Inductive modem and initially a surface mounted (30cm under the water surface) thermistor and bottom mounted SeaBird SBE39 (temperature and pressure). The buoy was decommissioned in 2014.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/324"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/325"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/326"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/328"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/329"/>
+	<dcterms:valid xml:lang="en">2009-12-07/2014-10-06</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/328">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Davies Reef Sensor Float 4</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-14T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-17T02:30:13Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">DAVSF4</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/41"/>
+	<skos:definition xml:lang="en">A round 1.4m yellow buoy has been deployed in the Davies Reef lagoon as part of the sensor network infrastructure at Davies Reef in the central Great Barrier Reef off Townsville, Australia. The buoy is configured as a sensor-float with a Campbell Scientific logger, a spread-spectrum radio for communicating with the on-reef wireless network, a SeaBird Inductive modem and initially a surface mounted (30cm under the water surface) thermistor and bottom mounted SeaBird SBE37 (conductivity, temperature and pressure). This buoy was decommissioned in March 2018. </skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/324"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/325"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/326"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/327"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/329"/>
+	<dcterms:valid xml:lang="en">2009-12-09/2016-01-06</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/329">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Davies Reef Sensor Float 5</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-14T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-17T02:31:32Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">DAVSF5</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/41"/>
+	<skos:definition xml:lang="en">A round 1.4m yellow buoy has been deployed in the Davies Reef lagoon as part of the sensor network infrastructure at Davies Reef in the central Great Barrier Reef off Townsville, Australia. The buoy is configured as a sensor-float with a Campbell Scientific logger, a spread-spectrum radio for communicating with the on-reef wireless network, a SeaBird Inductive modem and initially a surface mounted (30cm under the water surface) thermistor and bottom mounted SeaBird SBE37 (conductivity, temperature and pressure). This buoy was decommissioned in March 2018.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/324"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/325"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/326"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/327"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/328"/>
+	<dcterms:valid xml:lang="en">2009-12-09/2016-06-17</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/33">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">East Australian Current 500m Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-06-26T23:52:58Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T06:15:02Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">EAC0500</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The East Australian Current 500m Mooring is operated by CSIRO Oceans and Atmosphere, and collects data in the East Australian Current. This mooring forms part of the second deployment of the EAC array, and was reconfigured to incorporate parts of the continental shelf. </skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-27.3291,nominal longitude:153.8989,nominal depth:500m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/34"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/35"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/36"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/37"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/330">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">One Tree Island Base Station</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-14T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T06:32:08Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">One_Tree_Island</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/14"/>
+	<skos:definition xml:lang="en">The infrastructure consists of a base station mounted on the existing water tower, using the Telstra nextG service, and three sensor poles located in each of the major lagoon systems around the island. The base station collects data from the outlying sensor stations (RP1-RP3) within the lagoon of One Tree Island as well as having a LiCor 192 PAR sensor. The base station consists of a Campbell Scientific CR1000 logger that talks back to the mainland via a 5m mast located on the top of the tower and a Cybertec nextG modem, and to the rest of the equipment in the lagoon via a 900 MHz spread-spectrum Campbell RF411 radio. The station is powered off the research station power supply but has its own solar panel and battery supply in case of power outages.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/331"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/332"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/333"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/331">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">One Tree Island Relay Pole 1</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-14T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T06:31:39Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">OTIRP1</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/16"/>
+	<skos:definition xml:lang="en">A 6m steel pole has been installed within Central Bommie within the main lagoon of One Tree Island as part of the sensor network infrastructure at One Tree Island in the southern Great Barrier Reef off Gladstone, Australia. The sensor-relay pole provides a platform for the installation of sensors to measure and monitor water conditions within the lagoon of One Tree Island. The pole has real time communications using 900MHz spread spectrum radio back to a base station on One Tree Island. The pole is initially configured with a single thermistor string with six thermistors that is located down the outer wall of the bommie into the main lagoon and so provides a temperature profile of the main lagoon of One Tree Island. The data is collected every 10 minutes and relayed via the base station to the Data Centre at the Australian Institute of Marine Science (AIMS). The system uses a Campbell Scientific logger into which the sensors are connected. The equipment is serviced every six months with plans to install additional instruments such as pressure and salinity. The pole is available for mounting of additional third part instruments and so forms an infrastructure to support future observational work at the Island.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/330"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/332"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/333"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/332">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">One Tree Island Relay Pole 2</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-14T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T06:31:58Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">OTIRP2</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/16"/>
+	<skos:definition xml:lang="en">A 6m steel pole has been installed within a small bommie within Second Lagoon of One Tree Island as part of the sensor network infrastructure at One Tree Island in the southern Great Barrier Reef off Gladstone, Australia. The sensor-relay pole provides a platform for the installation of sensors to measure and monitor water conditions within the lagoon of One Tree Island. The pole has real time communications using 900MHz spread spectrum radio back to a base station on One Tree Island. The pole is initially configured with a single thermistor string with six thermistors that is located down the outer wall of the bommie into the second lagoon and so provides a temperature profile of the second lagoon of One Tree Island. The data is collected every 10 minutes and relayed via the base station to the Data Centre at the Australian Institute of Marine Science (AIMS). The system uses a Campbell Scientific logger into which the sensors are connected. The equipment is serviced every six months with plans to install additional instruments such as pressure and salinity. The pole is available for mounting of additional third part instruments and so forms an infrastructure to support future observational work at the Island.The pole was decommissioned in September 2017.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/330"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/331"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/333"/>
+	<dcterms:valid xml:lang="en">2008-11-19/2017-09-16</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/333">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">One Tree Island Relay Pole 3</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-14T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T06:32:08Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">OTIRP3</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/16"/>
+	<skos:definition xml:lang="en">A 6m steel pole has been installed within a small bommie in Third Lagoon on One Tree Island as part of the sensor network infrastructure at One Tree Island in the southern Great Barrier Reef off Gladstone, Australia. The sensor-relay pole provides a platform for the installation of sensors to measure and monitor water conditions within the lagoon of One Tree Island. The pole has real time communications using 900MHz spread spectrum radio back to a base station on One Tree Island. The pole is initially configured with a single thermistor string with six thermistors that is located down the outer wall of the bommie into the lagoon and so provides a temperature profile of the third lagoon of One Tree Island. The data is collected every 10 minutes and relayed via the base station to the Data Centre at the Australian Institute of Marine Science (AIMS). The system uses a Campbell Scientific logger into which the sensors are connected. The equipment is serviced every six months with plans to install additional instruments such as pressure and salinity. The pole is available for mounting of additional third part instruments and so forms an infrastructure to support future observational work at the Island. A Vaisala WXT520 integrated weather station has been installed on RP3. The weather station provides measurement of air temperature (Deg. C.), humidity as relative percent, barometric pressure (milliBars or hPa), rainfall amount, intensity and duration, hail amount, intensity and duration (not common on coral reefs!) and wind speed and direction. The wind speed and direction and processed into scalar and vector (directional) based readings and presented as 10 and 30 minute averages to give mean values and maximum values. From these you can get the average wind conditions at either 10 minute or 30 minute periods as well as the gust or maximum wind conditions. The weather station is connected via an SDI-12 interface to a Campbell Scientific CR1000 logger which uses a RF411 radio to transmit the data, every 10 minutes, to the base station on One Tree Island and then a Telstra nextG link is used to send the data back to AIMS. The pole was decommissioned in September 2017.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/330"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/331"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/332"/>
+	<dcterms:valid xml:lang="en">2008-11-19/2017-09-17</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/334">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Heron Island Base Station</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-14T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T06:30:08Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">Heron_Island</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/14"/>
+	<skos:definition xml:lang="en">The infrastructure consists of a base station mounted on the existing telecommunications tower, eight sensor poles that create the on-reef network and five sensor floats on which the sensors are attached. One of the poles (RP5) also has a weather station mounted on it.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/335"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/336"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/337"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/338"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/339"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/340"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/341"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/342"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/343"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/344"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/345"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/346"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/347"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/335">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Heron Island Relay Pole 1</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-14T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T06:25:04Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">HIRP1</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/16"/>
+	<skos:definition xml:lang="en">A 6m steel pole. The pole is solar powered and routes data from the Sensor Floats and other Sensor Relay Poles back to the Base Station located on Heron Island. The system uses the Campbell Scientific CR1000 loggers and RF411 Spread-Spectrum radios to process and route the data. The poles also can support a range of sensors, this pole also has a simple bottom mounted thermistor using the MEA thermistors. The unit will be serviced every six months and will be used in the future for attaching new sets of sensors.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/334"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/336"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/337"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/338"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/339"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/340"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/341"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/342"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/343"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/344"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/345"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/346"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/347"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/336">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Heron Island Relay Pole 2</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-14T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T06:26:58Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">HIRP2</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/16"/>
+	<skos:definition xml:lang="en">A 6m steel pole. The pole is solar powered and routes data from the Sensor Floats and other Sensor Relay Poles back to the Base Station located on Heron Island. The system uses the Campbell Scientific CR1000 loggers and RF411 Spread-Spectrum radios to process and route the data. The poles also can support a range of sensors, this pole also has a simple bottom mounted thermistor using the MEA thermistors. The unit will be serviced every six months and will be used in the future for attaching new sets of sensors.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/334"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/335"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/337"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/338"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/339"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/340"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/341"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/342"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/343"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/344"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/345"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/346"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/347"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/337">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Heron Island Relay Pole 3</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-14T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T06:27:52Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">HIRP3</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/16"/>
+	<skos:definition xml:lang="en">A 6m steel pole.  The pole is solar powered and routes data from the Sensor Floats and other Sensor Relay Poles back to the Base Station located on Heron Island. The system uses the Campbell Scientific CR1000 loggers and RF411 Spread-Spectrum radios to process and route the data. The poles also can support a range of sensors, this pole also has a simple bottom mounted thermistor using the MEA thermistors. The unit will be serviced every six months and will be used in the future for attaching new sets of sensors.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/334"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/335"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/336"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/338"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/339"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/340"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/341"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/342"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/343"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/344"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/345"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/346"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/347"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/338">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Heron Island Relay Pole 4</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-14T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T06:28:35Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">HIRP4</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/16"/>
+	<skos:definition xml:lang="en">A 6m steel pole. The pole is solar powered and routes data from the Sensor Floats and other Sensor Relay Poles back to the Base Station located on Heron Island. The system uses the Campbell Scientific CR1000 loggers and RF411 Spread-Spectrum radios to process and route the data. The poles also can support a range of sensors, this pole also has a simple bottom mounted thermistor using the MEA thermistors. The unit will be serviced every six months and will be used in the future for attaching new sets of sensors. </skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/334"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/335"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/336"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/337"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/339"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/340"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/341"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/342"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/343"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/344"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/345"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/346"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/347"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/339">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Heron Island Relay Pole 5</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-14T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T06:29:12Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">HIRP5</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/16"/>
+	<skos:definition xml:lang="en">A 6m steel pole. The pole is solar powered and routes data from the Sensor Floats and other Sensor Relay Poles back to the Base Station located on Heron Island. The system uses the Campbell Scientific CR1000 loggers and RF411 Spread-Spectrum radios to process and route the data. The poles also can support a range of sensors, this pole also has a simple bottom mounted thermistor using the MEA thermistors as well as a Vaisala WXT520 weather station. The unit will be serviced every six months and will be used in the future for attaching new sets of sensors. The weather station provides measurement of air temperature (Deg. C.), humidity as relative percent, barometric pressure (milliBars or hPa), rainfall amount, intensity and duration, hail amount, intensity and duration (not common on coral reefs!) and wind speed and direction. The wind speed and direction and processed into scalar and vector (directional) based readings and presented as 10 and 30 minute averages to give mean values and maximum values. From these you can get the average wind conditions at either 10 minute or 30 minute periods as well as the gust or maximum wind conditions. The weather station is connected via an SDI-12 interface to a Campbell Scientific CR1000 logger which uses a RF411 radio to transmit the data, every 10 minutes, to the base station on Heron Island and then a Telstra nextG link is used to send the data back to AIMS.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/334"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/335"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/336"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/337"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/338"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/340"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/341"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/342"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/343"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/344"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/345"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/346"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/347"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/34">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">East Australian Current 2000m Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-06-26T23:55:17Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T06:13:38Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">EAC2000</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The East Australian Current 2000m Mooring is operated by CSIRO Oceans and Atmosphere, and collects data in the East Australian Current. This mooring forms part of the second deployment of the EAC array, and was reconfigured to incorporate parts of the continental shelf. </skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-27.3175,nominal longitude:154.0017,nominal depth:2000m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/33"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/35"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/36"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/37"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/38"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/340">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Heron Island Relay Pole 6</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-14T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T06:29:41Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">HIRP6</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/16"/>
+	<skos:definition xml:lang="en">A 6m steel pole. The pole is solar powered and routes data from the Sensor Floats and other Sensor Relay Poles back to the Base Station located on Heron Island. The system uses the Campbell Scientific CR1000 loggers and RF411 Spread-Spectrum radios to process and route the data. The poles also can support a range of sensors, this pole also has a simple bottom mounted thermistor using the MEA thermistors. The unit will be serviced every six months and will be used in the future for attaching new sets of sensors.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/334"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/335"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/336"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/337"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/338"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/339"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/341"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/342"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/343"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/344"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/345"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/346"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/347"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/341">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Heron Island Relay Pole 7</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-14T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T06:30:00Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">HIRP7</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/16"/>
+	<skos:definition xml:lang="en">A 6m steel pole. This pole was to be installed in April 2013, in the Wistari Channel.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/334"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/335"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/336"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/337"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/338"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/339"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/340"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/342"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/343"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/344"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/345"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/346"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/347"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/342">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Heron Island Relay Pole 8</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-14T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T06:30:08Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">HIRP8</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/16"/>
+	<skos:definition xml:lang="en">A 6m steel pole. The pole is solar powered and routes data from the Sensor Floats and other Sensor Relay Poles back to the Base Station located on Heron Island. The system uses the Campbell Scientific CR1000 loggers and RF411 Spread-Spectrum radios to process and route the data. The poles also can support a range of sensors. The unit will be serviced every six months and will be used in the future for attaching new sets of sensors.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/334"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/335"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/336"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/337"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/338"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/339"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/340"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/341"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/343"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/344"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/345"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/346"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/347"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/343">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Heron Island Sensor Float 1</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-14T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T05:37:59Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">HISF1</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/41"/>
+	<skos:definition xml:lang="en">A round 1.4m yellow buoy has been deployed in the Heron Island lagoon as part of the sensor network infrastructure at Heron Island in the southern Great Barrier Reef off Gladstone, Australia. The buoy is configured as a sensor-float with a Campbell Scientific logger, a spread-spectrum radio for communicating with the on-reef wireless network, a GPS and initially a surface mounted (30cm under the water surface) thermistor. The float is moored in the lagoon of Heron Island in around 3m of water and will be used to monitor the flow of water through the lagoon. It will be fitted with surface salinity and bottom depth and temperature in late 2008. The unit will be serviced every six months and will be used in the future for attaching new sets of sensors. The buoy is re-locatable and the GPS data should be used to find the current location.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/334"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/335"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/336"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/337"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/338"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/339"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/340"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/341"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/342"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/344"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/345"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/346"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/347"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/344">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Heron Island Sensor Float 2</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-14T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T05:40:13Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">HISF2</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/41"/>
+	<skos:definition xml:lang="en">A round 1.4m yellow buoy has been deployed in the Heron Island lagoon as part of the sensor network infrastructure at Heron Island in the southern Great Barrier Reef off Gladstone, Australia. The buoy is configured as a sensor-float with a Campbell Scientific logger, a spread-spectrum radio for communicating with the on-reef wireless network, a GPS and initially a surface mounted (30cm under the water surface) thermistor. The float is moored in the lagoon of Heron Island in around 3m of water and will be used to monitor the flow of water through the lagoon. It will be fitted with surface salinity and bottom depth and temperature in late 2008. The unit will be serviced every six months and will be used in the future for attaching new sets of sensors. The buoy is re-locatable and the GPS data should be used to find the current location. This buoy was decommissioned in 2016.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/334"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/335"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/336"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/337"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/338"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/339"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/340"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/341"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/342"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/343"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/345"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/346"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/347"/>
+	<dcterms:valid xml:lang="en">2008-12-23/2016-03-13</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/345">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Heron Island Sensor Float 3</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-14T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T05:41:34Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">HISF3</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/41"/>
+	<skos:definition xml:lang="en">A round 1.4m yellow buoy has been deployed in the Heron Island lagoon as part of the sensor network infrastructure at Heron Island in the southern Great Barrier Reef off Gladstone, Australia. The buoy is configured as a sensor-float with a Campbell Scientific logger, a spread-spectrum radio for communicating with the on-reef wireless network, a GPS and initially a surface mounted (30cm under the water surface) thermistor. The float is moored in the lagoon of Heron Island in around 3m of water and will be used to monitor the flow of water through the lagoon. It will be fitted with surface salinity and bottom depth and temperature in late 2008. The unit will be serviced every six months and will be used in the future for attaching new sets of sensors. The buoy is re-locatable and the GPS data should be used to find the current location. This buoy was decommissioned in 2017.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/334"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/335"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/336"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/337"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/338"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/339"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/340"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/341"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/342"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/343"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/344"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/346"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/347"/>
+	<dcterms:valid xml:lang="en">2008-12-22/2016-04-11</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/346">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Heron Island Sensor Float 4</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-14T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T05:42:51Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">HISF4</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/41"/>
+	<skos:definition xml:lang="en">A round 1.4m yellow buoy has been deployed in the Heron Island lagoon as part of the sensor network infrastructure at Heron Island in the southern Great Barrier Reef off Gladstone, Australia. The buoy is configured as a sensor-float with a Campbell Scientific logger, a spread-spectrum radio for communicating with the on-reef wireless network, a GPS and initially a surface mounted (30cm under the water surface) thermistor. The float is moored in the lagoon of Heron Island in around 3m of water and will be used to monitor the flow of water through the lagoon. It will be fitted with surface salinity and bottom depth and temperature in late 2008.  The unit will be serviced every six months and will be used in the future for attaching new sets of sensors. The buoy is re-locatable and the GPS data should be used to find the current location. This buoy was decommissioned in 2015.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/334"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/335"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/336"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/337"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/338"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/339"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/340"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/341"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/342"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/343"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/344"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/345"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/347"/>
+	<dcterms:valid xml:lang="en">2008-12-22/2013-12-19</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/347">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Heron Island Sensor Float 5</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-06-14T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T05:43:55Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">HISF5</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/41"/>
+	<skos:definition xml:lang="en">A round 1.4m yellow buoy has been deployed in the Heron Island lagoon as part of the sensor network infrastructure at Heron Island in the southern Great Barrier Reef off Gladstone, Australia. The buoy is configured as a sensor-float with a Campbell Scientific logger, a spread-spectrum radio for communicating with the on-reef wireless network, a GPS and initially a surface mounted (30cm under the water surface) thermistor. The float is moored in the lagoon of Heron Island in around 3m of water and will be used to monitor the flow of water through the lagoon. It will be fitted with surface salinity and bottom depth and temperature in late 2008. The unit will be serviced every six months and will be used in the future for attaching new sets of sensors. The buoy is re-locatable and the GPS data should be used to find the current location. This buoy was decommissioned in 2017.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/334"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/335"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/336"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/337"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/338"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/339"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/340"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/341"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/342"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/343"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/344"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/345"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/346"/>
+	<dcterms:valid xml:lang="en">2008-12-22/2016-09-19</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/35">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">East Australian Current 3200m Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-06-26T23:56:26Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T06:14:17Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">EAC3200</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The East Australian Current 3200m Mooring is operated by CSIRO Oceans and Atmosphere, and collects data in the East Australian Current. This mooring forms part of the second deployment of the EAC array, and was reconfigured to incorporate parts of the continental shelf. </skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-27.2839,nominal longitude:154.1367,nominal depth:3200m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/33"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/34"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/36"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/37"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/38"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/36">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">East Australian Current 4200m Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-06-26T23:57:20Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T06:14:44Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">EAC4200</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The East Australian Current 4200m Mooring is operated by CSIRO Oceans and Atmosphere, and collects data in the East Australian Current. This mooring forms part of the second deployment of the EAC array, and was reconfigured to incorporate parts of the continental shelf. </skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-27.2391,nominal longitude:154.291,nominal depth:4200m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/33"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/34"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/35"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/37"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/38"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/37">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">East Australian Current 4700m Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-06-26T23:58:28Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T06:15:02Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">EAC4700</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The East Australian Current 4700m Mooring is operated by CSIRO Oceans and Atmosphere, and collects data in the East Australian Current. This mooring forms part of the second deployment of the EAC array, and was reconfigured to incorporate parts of the continental shelf. </skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-27.2086,nominal longitude:154.645,nominal depth:4700m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/33"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/34"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/35"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/36"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/38"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/38">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">East Australian Current 4800m Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-06-26T23:59:33Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T06:14:55Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">EAC4800</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The East Australian Current 4800m Mooring is operated by CSIRO Oceans and Atmosphere, and collects data in the East Australian Current. This mooring forms part of the second deployment of the EAC array, and was reconfigured to incorporate parts of the continental shelf. </skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-27.1083,nominal longitude:155.2883,nominal depth:4800m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/34"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/35"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/36"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/37"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/4">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Kaharoa</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-07T03:31:18Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Natalia_Atkins"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T03:52:33Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">ZM7552</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/31"/>
+	<skos:definition xml:lang="en">Research vessel owned by NIWA, currently flying the flag of New Zealand (July 2015).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:8000898</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1981</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/61LY/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/453">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Tropical Islander</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-07-24T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:58:41Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">3FLZ</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">General Cargo ship vessel, which is currently flying the flag of Panama (July 2013).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9385219</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2009</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/PATI/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/454">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">CMA CGM Onyx</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-07-24T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:17:17Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">9VBM5</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Singapore (July 2013).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9334143</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2007</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/SIOX/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/455">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Cap Reinga</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-07-24T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:25:30Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">A8FA6</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel. It was called the Cap Reinga from August 2007 until September 2010. It is now called the Jupiter (Liberia, November 2012).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9226504</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2001</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/54AO/"/>
+	<owl:sameAs rdf:resource="http://vocab.aodn.org.au/def/platform/entity/456"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/456">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">CSCL Longkou</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-07-24T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:41Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">A8FA6</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel. It was called the CSCL Longkou from May 2001 until Augus 2007. It is now called the Jupiter (Liberia, November 2012).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9226504</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2001</skos:scopeNote>
+	<owl:sameAs rdf:resource="http://vocab.aodn.org.au/def/platform/entity/455"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/457">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">CMA CGM Lavender</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-07-24T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:16:25Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">A8IG2</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Liberia (July 2013).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9314973</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2006</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/54LB/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/458">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">ANL Benalla</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-07-24T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T04:07:23Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">A8JM5</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Liberia (July 2013).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9334519</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2006</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/54CM/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/459">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">JPO Scorpius</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-07-24T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:37:16Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">A8KC6</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Liberia (July 2013).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9307279</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2007</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/54CW/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/460">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Maersk Fuji</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-07-24T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:40Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">C4BZ2</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel. It was called the Maersk Fuji from July 2005 unitl June 2010. It is now called the Spyros (Marshall Islands, February 2012).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9308584</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2005</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/461">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Merkur Sky</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-07-24T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:44:59Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">DDPH</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel. It was called the Merkur Sky from 1997 to April 1998, December 1998 to 1999, May 2001 to March 2002, November 2002 to June 2003, August 2005 to July 2007 and April 2011 to September 2012. It is now called the M Sky (Saint Kitts &amp; Nevis, June 2012). It was disposed of in approximately 2012. </skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9158977</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1997</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/06M7/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/462">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Icebird</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-07-24T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:34:43Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">DPIB</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Cargo ship vessel. It was called the Icebird from 1984 until December 1994. It is now called the Almog (Honduras, November 2012).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:8403533</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1984</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/06CE/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/463">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Hoegh Seoul</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-07-24T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-03-27T21:49:32Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">LADO6</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Vehicles carrier vessel, which is currently flying the flag of Norway (July, 2013).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9285495</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2004</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/58SM/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/464">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Hoegh St. Petersburg</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-07-24T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:34:23Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">LAII7</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Vehicles carrier vessel, which is currently flying the flag of Norway (July, 2013).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9420045</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2009</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/58EN/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/465">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Conti Harmony</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-07-24T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:26:52Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">P3JM9</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Cyprus (July 2013). It was disposed of in approximately 2014.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9137894</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1997</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/CYCS/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/466">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Schelde Trader</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-07-24T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:54:19Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">PBKZ</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Netherlands (July 2013).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9264752</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2003</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/64AD/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/467">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Maersk Fukuoka</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-07-24T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:41:00Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">V2BM5</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel. It was called the Maersk Fukuoka from 2005 until December 2010. It is now called the Georgia (Marshall Islands, September 2011).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9308601</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2005</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/AGMF/"/>
+	<owl:sameAs rdf:resource="http://vocab.aodn.org.au/def/platform/entity/468"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/468">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Isar Trader</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-07-24T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:40Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">V2BM5</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel. It was called the Isar Trader from December 2010 until August 2012. It is now called the Georgia (Marshall Islands, September 2011).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9308601</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2005</skos:scopeNote>
+	<owl:sameAs rdf:resource="http://vocab.aodn.org.au/def/platform/entity/467"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/469">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Sofrana Surville</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-07-24T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:55:27Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">V2CN5</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Antigua and Barbuda (July 2013).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9295529</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2007</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/AGSD/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/470">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">BC San Francisco</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-07-24T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T04:37:47Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">V2QD4</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Antigua and Barbuda (June 2013).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9346562</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2006</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/AGSF/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/471">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">CMA CGM Jade</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-07-24T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:33Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">V7NX2</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Marshall Islands (July 2013).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9324875</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2007</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/472">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Santos Express</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-07-24T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:53:55Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VRCF6</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Hong Kong (July 2013).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9301835</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2006</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/HKSE/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/473">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Manila Express</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-07-24T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:41:58Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VRCX7</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Hong Kong (July 2013).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9301859</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2007</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/HKME/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/474">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Pacific Gas</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-07-24T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:50:13Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">YJZC5</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">LPG Tanker vessel, which is currently flying the flag of Vanuatu (October 2012).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:8915421</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1991</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/VUPG/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/475">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Mississauga Express</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-07-24T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:45:18Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">ZCBP6</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Bermuda (July 2013).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9165358</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1998</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/BMMX/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/5">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Kangaroo Island, SA Passive Acoustic Observatory</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-11-09T01:47:35Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-17T04:53:47Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">PAKAI</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/43"/>
+	<skos:definition xml:lang="en">The Kangaroo Island, SA Passive Acoustic Observatory, is a series of moorings operated by SARDI (South Australian Research and Development Institute) which collect data west of Kangaroo Island. This observatory was decommissioned in November 2017. </skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-36.11365,nominal longitude:135.88253333,nominal depth:181m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/178"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/179"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/180"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/904"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/905"/>
+	<dcterms:valid xml:lang="en">2014-12-08/2017-11-28</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/560">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Bass Strait Calibration site Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-10-31T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-17T04:52:25Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">SRSBAS</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/43"/>
+	<skos:definition xml:lang="en">This calibration site mooring is located in Bass Strait. This is used for the calibration of the TOPEX/Poseidon (T/P) and Jason-1 satellite altimeters. This location lies on the descending (N -&gt; S) pass 088 of the satellite altimeter, and thus shares similar satellite orbit characteristics to the Storm Bay mooring. The use of these two sites allows detailed investigation into the accuracy of the altimeter over two different wave climates. The average significant wave height at Storm Bay is approximately double that observed at the comparatively sheltered Bass Strait location. This mooring is operated by CSIRO.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-40.65,nominal longitude:145.594,nominal depth:52m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/561"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/561">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Storm Bay Calibration site Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-10-31T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-17T04:52:25Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">SRSSTO</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/43"/>
+	<skos:definition xml:lang="en">This calibration site mooring is located in Storm Bay. This is used for the calibration of the TOPEX/Poseidon (T/P) and Jason-1 satellite altimeters. This location lies on the descending (N -&gt; S) pass 088 of the satellite altimeter, and thus shares similar satellite orbit characteristics to the Bass Strait mooring. The use of these two sites allows detailed investigation into the accuracy of the altimeter over two different wave climates. The average significant wave height at Storm Bay is approximately double that observed at the comparatively sheltered Bass Strait location. This mooring is operated by CSIRO. This mooring was decommissioned in September 2016.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-43.3,nominal longitude:147.661,nominal depth:95m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/560"/>
+	<dcterms:valid xml:lang="en">2009-04-05/2016-09-16</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/6">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Geelong Star</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-01-04T01:52:07Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-02T23:33:31Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VHKJ</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/36"/>
+	<skos:definition xml:lang="en">Fishing vessel, currently flying the Netherlands flag (January 2017)</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:8209171</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1983</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/65">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Heron Island North mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-04-10T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T06:35:48Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">GBRHIN</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Heron Island North Mooring is operated by AIMS (Australian Institute of Marine Science) and collect data in Great Barrier Reef region. This mooring was decommissioned in March 2013.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-23.383335,nominal longitude:151.9833913,nominal depth:46m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/124"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/125"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/126"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/127"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/128"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/129"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/130"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/131"/>
+	<dcterms:valid xml:lang="en">2007-09-12/2013-03-16</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/66">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Maria Island National Reference Station ADCP mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-04-10T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T06:46:22Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">NRSMAI-ADCP</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">ADCP mooring located at the Maria Island National Reference Station. This mooring is operated by CSIRO.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-42.5998,nominal longitude:148.2326,nominal depth:90m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/141"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/142"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/143"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/145"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/146"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/147"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/148"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/149"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/150"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/151"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/152"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/67"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/68"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/67">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Maria Island National Reference Station sub-surface mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-04-10T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T01:46:00Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">NRSMAI-SubSurface</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/43"/>
+	<skos:definition xml:lang="en">Sub-surface mooring located at the Maria Island National Reference Station. This mooring is operated by CSIRO.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-42.597,nominal longitude:148.233,nominal depth:90m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/141"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/142"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/146"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/147"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/149"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/150"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/66"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/68"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/68">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Maria Island National Reference Station surface mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-04-10T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T06:49:50Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">NRSMAI-Surface</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">Surface mooring located at the Maria Island National Reference Station. This mooring is operated by CSIRO.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-42.597,nominal longitude:148.233,nominal depth:90m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/141"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/142"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/143"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/145"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/146"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/147"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/148"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/149"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/150"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/151"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/152"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/66"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/67"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/69">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Maria Island National Reference Station Acidification Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-04-10T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-13T06:43:44Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">NRSMAI-CO2</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">Acidification mooring located at the Maria Island National Reference Station. This mooring is operated by CSIRO.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-42.597,nominal longitude:148.233,nominal depth:90m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/144"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/898"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/899"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/7">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Empress Pearl</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-01-04T01:55:41Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-02T23:33:13Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VM7743</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/36"/>
+	<skos:definition xml:lang="en">Trawler fishing vessel, currently flying the Australian flag (January, 2017)</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:8409214</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1987</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/71">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Cape Ferguson</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-04-11T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T03:49:06Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VNCF</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/31"/>
+	<skos:definition xml:lang="en">Research vessel owned by the Australian Institute of Marine Science (AIMS). Active as Mar 2013.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9240861</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2000</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/097H/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/72">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Solander</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-04-11T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T04:00:32Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VMQ9273</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/31"/>
+	<skos:definition xml:lang="en">Research vessel owned by the Australian Institute of Marine Science (AIMS). Active as Mar 2013.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9423463</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2007</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/09CX/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/726">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">WERA beam forming HF radar</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2014-06-19T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:45Z</dcterms:modified>
+	<skos:definition xml:lang="en"></skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/42"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/727">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">SeaSonde direction finding HF radar</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/superadmin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2014-06-19T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-12-19T04:00:54Z</dcterms:modified>
+	<skos:definition xml:lang="en"></skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/42"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/73">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Spirit of Tasmania 1</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2103-04-11T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-17T04:56:51Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VLST</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/35"/>
+	<skos:definition xml:lang="en">Spirit of Tasmania 1 is owned by the TT-Line Company. It was built in 1998 by Kvaerner Masa-Yards in Finland as Superfast IV on the Patras-Ancona route. Since 2002, It is operating on the Melbourne (Victoria) - Devonport (Tasmania) route across Bass Strait</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO: 9158446</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1998</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/100"/>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/09TF/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/74">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Sirius</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-04-11T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:38Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/25"/>
+	<skos:definition xml:lang="en">The IMOS AUV facility owns and operates the ocean going AUV called Sirius. Managed by the University of Sydney's Australian Centre for Field Robotics (ACFR), this vehicle is a modified version of a mid-size robotic vehicle called Seabed built at the Woods Hole Oceanographic Institution</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/8">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Antarctic Discovery</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-01-04T01:57:47Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-02T23:32:14Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VKAD</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/36"/>
+	<skos:definition xml:lang="en">Fishing vessel, currently flying the Australian flag (January 2017)</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9123219</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1995</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/823">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">small boat</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-04-14T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:43Z</dcterms:modified>
+	<skos:definition xml:lang="en">A small self-propelled platform operating on the surface of the water column in unpredictable locations that is smaller than a ship but too large to easily remove from the water.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/39"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/863">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">NOAA-8</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-03T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-02-15T03:46:29Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/65"/>
+	<skos:definition xml:lang="en">This satellite was the 4th flight unit of the NOAA 4th generation programme, and 1st of the ATN series. It operated between March 1983 and December 1985 at an altitutde of 820km, in a sunsynchronous orbit. Instrumentation: Argos Data Collection System , Advanced Very High Resolution Radiometer, High-resolution Infra Red Sounder / 2, Microwave Sounding Unit, Search and Rescue Satellite-Aided Tracking System, Stratospheric Sounding Unit, SEM / Medium energy proton detector and SEM / Total Energy Detector.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">National Oceanic and Atmospheric Administration</skos:hiddenLabel>
+	<skos:hiddenLabel xml:lang="en">NOAA 4th Generation - Polar Operational Environmental Satellites (POES) - NOAA-8</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/864"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/865"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/866"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/867"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/868"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/869"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/870"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/871"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/872"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/873"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/874"/>
+	<dcterms:valid xml:lang="en">1983-03-28/1985-12-29</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/864">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">NOAA-9</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-03T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-02-15T03:46:36Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/65"/>
+	<skos:definition xml:lang="en">This satellite was the 5th flight unit of the NOAA 4th generation programme, and 2nd of the ATN series. It operated between December 1984 and February 1998 at an altitutde of 850km, in a sunsynchronous orbit. Instrumentation: Argos Data Collection System, Advanced Very High Resolution Radiometer / 2, Earth Radiation Budget Experiment, High-resolution Infra Red Sounder / 2, Microwave Sounding Unit, Search and Rescue Satellite-Aided Tracking System, Solar Backscatter Ultraviolet / 2, Stratospheric Sounding Unit, SEM / Medium energy proton detector and SEM / Total Energy Detector</skos:definition>
+	<skos:hiddenLabel xml:lang="en">National Oceanic and Atmospheric Administration</skos:hiddenLabel>
+	<skos:hiddenLabel xml:lang="en">NOAA 4th Generation - Polar Operational Environmental Satellites (POES) - NOAA-9</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/863"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/865"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/866"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/867"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/868"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/869"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/870"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/871"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/872"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/873"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/874"/>
+	<dcterms:valid xml:lang="en">1984-12-12/1998-02-13</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/865">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">NOAA-10</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-03T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-02-15T03:45:25Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/65"/>
+	<skos:definition xml:lang="en">This satellite was the 6th flight unit of the NOAA 4th generation programme, and 3rd of the ATN series. It operated between September 1986 and August 2001 at an altitutde of 810km, in a sunsynchronous orbit. Instrumentation: Argos Data Collection System, Advanced Very High Resolution Radiometer, Earth Radiation Budget Experiment, High-resolution Infra Red Sounder / 2, Microwave Sounding Unit, Search and Rescue Satellite-Aided Tracking System, Solar Backscatter Ultraviolet / 2, Stratospheric Sounding Unit, SEM / Medium energy proton detector and SEM / Total Energy Detector</skos:definition>
+	<skos:hiddenLabel xml:lang="en">National Oceanic and Atmospheric Administration</skos:hiddenLabel>
+	<skos:hiddenLabel xml:lang="en">NOAA 4th Generation - Polar Operational Environmental Satellites (POES) - NOAA-10</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/863"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/864"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/866"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/867"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/868"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/869"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/870"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/871"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/872"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/873"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/874"/>
+	<dcterms:valid xml:lang="en">1986-09-17/2001-08-30</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/866">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">NOAA-11</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-03T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-02-15T03:45:33Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/65"/>
+	<skos:definition xml:lang="en">This satellite was the 7th flight unit of the NOAA 4th generation programme, and 4th of the ATN series. It operated between September 1988 and June 2004 at an altitutde of 843km, in a sunsynchronous orbit. Instrumentation: Argos Data Collection System, Advanced Very High Resolution Radiometer / 2, High-resolution Infra Red Sounder / 2, Microwave Sounding Unit, Search and Rescue Satellite-Aided Tracking System, Solar Backscatter Ultraviolet / 2, Stratospheric Sounding Unit, SEM / Medium energy proton detector and SEM / Total Energy Detector</skos:definition>
+	<skos:hiddenLabel xml:lang="en">National Oceanic and Atmospheric Administration</skos:hiddenLabel>
+	<skos:hiddenLabel xml:lang="en">NOAA 4th Generation - Polar Operational Environmental Satellites (POES) - NOAA-11</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/863"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/864"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/865"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/867"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/868"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/869"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/870"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/871"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/872"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/873"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/874"/>
+	<dcterms:valid xml:lang="en">1988-09-24/2004-06-16</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/867">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">NOAA-12</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-03T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-02-15T03:45:40Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/65"/>
+	<skos:definition xml:lang="en">This satellite was the 8th flight unit of the NOAA 4th generation programme, and 5th of the ATN series. It operated between May 1991 and August 2007 at an altitutde of 804km, in a sunsynchronous orbit. Instrumentation: Argos Data Collection System, Advanced Very High Resolution Radiometer / 2, High-resolution Infra Red Sounder / 2, Microwave Sounding Unit, Stratospheric Sounding Unit, SEM / Medium energy proton detector and SEM / Total Energy Detector</skos:definition>
+	<skos:hiddenLabel xml:lang="en">National Oceanic and Atmospheric Administration</skos:hiddenLabel>
+	<skos:hiddenLabel xml:lang="en">NOAA 4th Generation - Polar Operational Environmental Satellites (POES) - NOAA-12</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/863"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/864"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/865"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/866"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/868"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/869"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/870"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/871"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/872"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/873"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/874"/>
+	<dcterms:valid xml:lang="en">1991-05-14/2007-08-10</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/868">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">NOAA-13</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-03T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-02-15T03:45:46Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/65"/>
+	<skos:definition xml:lang="en">This satellite was the 9th flight unit of the NOAA 4th generation programme, and 6th of the ATN series. It operated between 09 August 1993 and 21 August 1993 at an altitutde of 820km, in a sunsynchronous orbit. Instrumentation: Argos Data Collection System, Advanced Very High Resolution Radiometer / 2, High-resolution Infra Red Sounder / 2, Microwave Sounding Unit, Search and Rescue Satellite-Aided Tracking System, Solar Backscatter Ultraviolet / 2, Stratospheric Sounding Unit, SEM / Medium energy proton detector and SEM / Total Energy Detector</skos:definition>
+	<skos:hiddenLabel xml:lang="en">National Oceanic and Atmospheric Administration</skos:hiddenLabel>
+	<skos:hiddenLabel xml:lang="en">NOAA 4th Generation - Polar Operational Environmental Satellites (POES) - NOAA-13</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/863"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/864"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/865"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/866"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/867"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/869"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/870"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/871"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/872"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/873"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/874"/>
+	<dcterms:valid xml:lang="en">1993-08-09/1993-08-21</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/869">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">NOAA-14</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-03T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-02-15T03:45:53Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/65"/>
+	<skos:definition xml:lang="en">This satellite was the 10th (last) flight unit of the NOAA 4th generation programme, and 7th of the ATN series. It operated between December 1994 and May 2007 at an altitutde of 844km, in a sunsynchronous orbit. Instrumentation: Argos Data Collection System, Advanced Very High Resolution Radiometer / 2, High-resolution Infra Red Sounder / 2, Microwave Sounding Unit, Search and Rescue Satellite-Aided Tracking System, Solar Backscatter Ultraviolet / 2, Stratospheric Sounding Unit, SEM / Medium energy proton detector and SEM / Total Energy Detector</skos:definition>
+	<skos:hiddenLabel xml:lang="en">National Oceanic and Atmospheric Administration</skos:hiddenLabel>
+	<skos:hiddenLabel xml:lang="en">NOAA 4th Generation - Polar Operational Environmental Satellites (POES) - NOAA-14</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/863"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/864"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/865"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/866"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/867"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/868"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/870"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/871"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/872"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/873"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/874"/>
+	<dcterms:valid xml:lang="en">1994-12-30/2007-05-23</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/870">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">NOAA-15</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-03T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-02-15T03:45:59Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/65"/>
+	<skos:definition xml:lang="en">This satellite was the 1st flight of the NOAA 5th generation programme. It operated between May 1998 and 2018, at an altitude of 807km, in a sunsynchronous orbit. Instrumentation: Advanced Microwave Sounding Unit - A, Advanced Microwave Sounding Unit - B, Advanced Very High Resolution Radiometer / 3, High-resolution Infra Red Sounder / 3, Search and Rescue Satellite-Aided Tracking System, Data Collection System / 2 (also called Argos-2), SEM / Medium energy proton detector and SEM / Total Energy Detector
+        
+        </skos:definition>
+	<skos:hiddenLabel xml:lang="en">National Oceanic and Atmospheric Administration</skos:hiddenLabel>
+	<skos:hiddenLabel xml:lang="en">NOAA 5th Generation - Polar Operational Environmental Satellites (POES) - NOAA-15</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/863"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/864"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/865"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/866"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/867"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/868"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/869"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/871"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/872"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/873"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/874"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/871">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">NOAA-16</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-03T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-02-15T03:46:05Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/65"/>
+	<skos:definition xml:lang="en">This satellite was the 2nd flight of the NOAA 5th generation programme. It operated between September 2000 and June 2014, at an altitude of 849km, in a sunsynchronous orbit. Instrumentation: Advanced Microwave Sounding Unit - A, Advanced Microwave Sounding Unit - B, Advanced Very High Resolution Radiometer / 3, High-resolution Infra Red Sounder / 3, Search and Rescue Satellite-Aided Tracking System, Solar Backscatter Ultraviolet / 2, Data Collection System / 2 (also called Argos-2), SEM / Medium energy proton detector and SEM / Total Energy Detector</skos:definition>
+	<skos:hiddenLabel xml:lang="en">National Oceanic and Atmospheric Administration</skos:hiddenLabel>
+	<skos:hiddenLabel xml:lang="en">NOAA 5th Generation - Polar Operational Environmental Satellites (POES) - NOAA-16</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/863"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/864"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/865"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/866"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/867"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/868"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/869"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/870"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/872"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/873"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/874"/>
+	<dcterms:valid xml:lang="en">2000-09-21/2014-06-09</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/872">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">NOAA-17</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-03T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-02-15T03:46:11Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/65"/>
+	<skos:definition xml:lang="en">This satellite was the 3rd flight of the NOAA 5th generation programme. It operated between June 2002 and April 2013, at an altitude of 810km, in a sunsynchronous orbit. Instrumentation: Advanced Microwave Sounding Unit - A, Advanced Microwave Sounding Unit - B, Advanced Very High Resolution Radiometer / 3, High-resolution Infra Red Sounder / 3, Search and Rescue Satellite-Aided Tracking System, Solar Backscatter Ultraviolet / 2, Data Collection System / 2 (also called Argos-2), SEM / Medium energy proton detector and SEM / Total Energy Detector</skos:definition>
+	<skos:hiddenLabel xml:lang="en">National Oceanic and Atmospheric Administration</skos:hiddenLabel>
+	<skos:hiddenLabel xml:lang="en">NOAA 5th Generation - Polar Operational Environmental Satellites (POES) - NOAA-17</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/863"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/864"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/865"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/866"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/867"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/868"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/869"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/870"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/871"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/873"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/874"/>
+	<dcterms:valid xml:lang="en">2002-06-24/2013-04-10</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/873">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">NOAA-18</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-07T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-02-15T03:46:17Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/65"/>
+	<skos:definition xml:lang="en">This satellite was the 4th flight of the NOAA 5th generation programme. It operated between May 2005 and 2018, at an altitude of 854km, in a sunsynchronous orbit. Instrumentation: Advanced Microwave Sounding Unit - A, Advanced Very High Resolution Radiometer / 3, High-resolution Infra Red Sounder / 4, Microwave Humidity Sounding, Search and Rescue Satellite-Aided Tracking System, Solar Backscatter Ultraviolet / 2, Data Collection System / 2 (also called Argos-2), SEM / Medium energy proton detector and SEM / Total Energy Detector
+        
+        </skos:definition>
+	<skos:hiddenLabel xml:lang="en">National Oceanic and Atmospheric Administration</skos:hiddenLabel>
+	<skos:hiddenLabel xml:lang="en"> NOAA 5th Generation - Polar Operational Environmental Satellites (POES) - NOAA-18</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/863"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/864"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/865"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/866"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/867"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/868"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/869"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/870"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/871"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/872"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/874"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/874">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">NOAA-19</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-07T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-02-15T03:46:23Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/65"/>
+	<skos:definition xml:lang="en">This satellite was the 5th (last) flight of the NOAA 5th generation programme. It operated between February 2009 and 2018, at an altitude of 870km, in a sunsynchronous orbit. Instrumentation: Advanced Data Collection System (also called Argos-3), Advanced Microwave Sounding Unit - A, Advanced Very High Resolution Radiometer / 3, High-resolution Infra Red Sounder / 4, Microwave Humidity Sounding, Search and Rescue Satellite-Aided Tracking System, Solar Backscatter Ultraviolet / 2, SEM / Medium energy proton detector and SEM / Total Energy Detector
+        </skos:definition>
+	<skos:hiddenLabel xml:lang="en">National Oceanic and Atmospheric Administration</skos:hiddenLabel>
+	<skos:hiddenLabel xml:lang="en">NOAA 5th Generation - Polar Operational Environmental Satellites (POES) - NOAA-19</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/863"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/864"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/865"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/866"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/867"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/868"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/869"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/870"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/871"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/872"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/873"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/879">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Aqua</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-07T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-11-14T23:02:07Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/65"/>
+	<skos:definition xml:lang="en">          This satellite was the 2nd flight of the NASA EOS programme. It operated between May 2002 and 2018, at an altitude of 705km, in a sunsynchronous orbit. Instrumentation: Atmospheric Infra-Red Sounder, Advanced Microwave Scanning Radiometer for EOS, Advanced Microwave Sounding Unit - A, Clouds and the Earth’s Radiant Energy System, Humidity Sounder for Brazil and Moderate-resolution Imaging Spectro-radiometer
+        </skos:definition>
+	<skos:hiddenLabel xml:lang="en">NASA - Earth Observation System (EOS) - Aqua</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/881">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">OrbView-2</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-04T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-02T23:54:52Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/65"/>
+	<skos:definition xml:lang="en">This satellite was the only flight of the OrbView-2/SeaStar (former name) programme. It operated between August 1997 and December 2010, at an altitude of 705km, in a sunsynchronous orbit. Instrumentation: Sea-viewing Wide Field-of-view Sensor (SeaWiFS).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">GeoEye - OrbView-2 (former: SeaStar)</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<dcterms:valid xml:lang="en">1997-08-01/2010-12-11</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/882">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">SAC-D</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-04T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-02T23:55:09Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/65"/>
+	<skos:definition xml:lang="en">This satellite was the 4th flight of the Satélite de Aplicaciones Cientificas (SAC) Aquarius Mission programme. It operated between June 2011 and June 2015, at an altitude of 661km, in a sunsynchronous orbit. Instrumentation: Aquarius.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">CONAE/NASA - Satélite de Aplicaciones Cientificas (SAC) Aquarius Mission - SAC-D</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<dcterms:valid xml:lang="en">2011-06-10/2015-06-07</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/883">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">TOPEX-Poseidon</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-04T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-02T23:55:25Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/65"/>
+	<skos:definition xml:lang="en">This satellite was the only flight of the TOPEX-Poseidon programme. It operated between August 1992 and October 2005, at an altitude of 1336km, in a drifting orbit. Instrumentation: Doppler Orbitography and Radiopositioning Integrated by Satellite, GPS Demonstration Receiver, Laser Retroreflector Array, Single-frequency Solid-state Altimeter, TOPEX Microwave Radiometer, NASA Radar Altimeter.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">NASA/CNES - Topography Experiment - Positioning,Ocean,Solid Earth, Ice Dynamics, Orbital Navigator (TOPEX-Poseidon)</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<dcterms:valid xml:lang="en">1992-08-10/2005-10-09</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/884">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">JASON-1</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-04T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T06:41:39Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/65"/>
+	<skos:definition xml:lang="en">This satellite was the 1st flight of the JASON series. It operated between December 2001 and July 2013, at an altitude of 1324km, in a drifting orbit. Instrumentation: Doppler Orbitography and Radiopositioning Integrated by Satellite, JASON Microwave Radiometer, Laser Retroreflector Array, Poseidon 2, Turbo Rogue Space Receiver.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">NASA/CNES/EUMETSAT/NOAA - Joint Altimetry Satellite Oceanography Network (JASON) - JASON-1</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/885"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/886"/>
+	<dcterms:valid xml:lang="en">2001-22/2013-07</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/885">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">JASON-2</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-04T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T06:41:48Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/65"/>
+	<skos:definition xml:lang="en">          This satellite was the 2nd flight of the JASON series, also called the Ocean Surface Topography Mission (OSTM). It operated between June 2008 and is operational until 2018, at an altitude of 1336km, in a drifting orbit. Instrumentation: Advanced Microwave Radiometer, Doppler Orbitography and Radiopositioning Integrated by Satellite, Laser Retroreflector Array, Poseidon 3, Turbo Rogue Space Receiver.
+        </skos:definition>
+	<skos:hiddenLabel xml:lang="en">NASA/CNES/EUMETSAT/NOAA - Joint Altimetry Satellite Oceanography Network (JASON) - JASON-2</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/884"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/886"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/886">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">JASON-3</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-04T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T06:41:48Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/65"/>
+	<skos:definition xml:lang="en">This satellite will be the 3rd flight of the JASON series, also called the Ocean Surface Topography Mission (OSTM). It is planned to be operational between 2016 and 2021, at an altitude of 1336km, in a drifting orbit. Instrumentation: Advanced Microwave Radiometer, Doppler Orbitography and Radiopositioning Integrated by Satellite, Laser Retroreflector Array, Poseidon 3B, Turbo Rogue Space Receiver.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">NASA/CNES/EUMETSAT/NOAA - Joint Altimetry Satellite Oceanography Network (JASON) - JASON-3</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/884"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/885"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/887">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">GFO</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-04T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-02T23:50:43Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/65"/>
+	<skos:definition xml:lang="en">This satellite was the 2nd (last) flight of the GEOSat programme. It operated between February 1998 and October 2008 at an altitude of 784km, in a drifting orbit. Instrumentation: GEOSat Follow-On Radar Altimeter, Laser Retroreflector Array, Turbo Rogue Space Receiver and Water Vapor Radiometer.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">DoD/NASA - GEOSat Follow-on (GFO)</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<dcterms:valid xml:lang="en">1998-02/2008-10</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/890">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Maersk Jalan</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-02-24T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:41:20Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">9V3581</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Cargo ship vessel, which is currently flying the flag of Singapore (February 2016).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9294161</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2005</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/SIVG/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/891">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Patricia Schulte</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-02-24T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:51:41Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">5BPB3</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Cyprus (February 2016).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9294185</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2006</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/CY4W/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/892">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Siangtan</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-02-24T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:55:07Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">9V9832</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Cargo ship vessel, which is currently flying the flag of Singapore (February 2016).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9614529</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2013</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/SIWU/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/894">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Ramform Sovereign</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-03-30T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-03T00:01:56Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">9VBN9</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/31"/>
+	<skos:definition xml:lang="en">Research/survey vessel, currently flying the flag of Singapore (March 2016).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9390460</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2008</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/895">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Falkor</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-03-30T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T03:49:51Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">ZCYL5</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/31"/>
+	<skos:definition xml:lang="en">Research/survey vessel, operating for the Schmidt Ocean Institute, currently flying the flag of the Cayman Islands (March 2016).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:7928677</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1981</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/CIFR/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/896">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Isla Eden</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-03-30T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-02T23:33:59Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VJN4147</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/36"/>
+	<skos:definition xml:lang="en">Fishing vessel, currently flying the Australian flag (March 2016)</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9111694</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1994</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/897">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Saxon Onward</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-03-30T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-02T23:34:53Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VJT5748</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/36"/>
+	<skos:definition xml:lang="en">Fishing vessel, currently flying the Australian flag (March 2016)</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:5314987</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1960</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/898">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Wistari Channel acidification Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-04-15T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T05:51:09Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">GBRWIS-CO2</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">Acidification mooring located adjacent to the Heron Island reef slope in the Wistari channel on the Great Barrier Reef. This mooring is operated by AIMS (Australian Institute of Marine Science).</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-23.4586,nominal longitude:151.9267,nominal depth:10m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/144"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/69"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/899"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/899">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Yongala National Reference Station Acidification Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-04-15T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T05:51:09Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">NRSYON-CO2</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">Acidification mooring co-located with the Yongala National Reference Station (NRSYON) in Queensland. This mooring is operated by AIMS (Australian Institute of Marine Science). This mooring was decommissioned in August 2014. </skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-19.3094,nominal longitude:147.6295,nominal depth:22m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/144"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/69"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/898"/>
+	<dcterms:valid xml:lang="en">2013-09-17/2014-08-30</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/9">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Sniper</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-01-05T05:38:26Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-02T23:35:07Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VHN7652</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/36"/>
+	<skos:definition xml:lang="en">Fishing vessel, currently flying the Australian flag (January 2017)</skos:definition>
+	<skos:hiddenLabel xml:lang="en">MMSI:503798800</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/900">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">TOTTEN1 Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-04-15T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T05:46:23Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">TOTTEN1</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">Mooring 1 in the 2014-2015 Dalton/Totten mooring array, which was operated by CSIRO, and collects data adjacent to the Totten Glacier. This mooring was decommissioned in January 2015.  
+        </skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-66.5426,nominal longitude:119.2114,nominal depth:707m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/901"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/902"/>
+	<dcterms:valid xml:lang="en">2014-02-04/2015-01-03</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/901">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">TOTTEN2 Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-04-15T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T05:46:32Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">TOTTEN2</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">Mooring 2 in the 2014-2015 Dalton/Totten mooring array, which was operated by CSIRO, and collects data adjacent to the Totten Glacier. This mooring was decommissioned in January 2015.
+        </skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-66.2105,nominal longitude:120.6273,nominal depth:500m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/900"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/902"/>
+	<dcterms:valid xml:lang="en">2014-02-04/2015-01-03</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/902">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">TOTTEN3 Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-04-15T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T05:46:32Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">TOTTEN3</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">Mooring 3 in the 2014-2015 Dalton/Totten mooring array, which was operated by CSIRO, and collects data adjacent to the Totten Glacier. This mooring was decommissioned in January 2015. 
+        </skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-66.5014,nominal longitude:120.4566,nominal depth:549m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/900"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/901"/>
+	<dcterms:valid xml:lang="en">2014-02-04/2015-01-03</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/903">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Two Rocks 44m Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-04-15T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T05:50:24Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">WATR04</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Two Rocks 44m Shelf Mooring is operated by CSIRO and collects data in the Two Rocks region.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-31.7207,nominal longitude:115.4,nominal depth:44m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/170"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/171"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/172"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/173"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/174"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/904">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Kimberley, WA Passive Acoustic Observatory</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-04-15T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-17T04:54:21Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">PAKIM</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/43"/>
+	<skos:definition xml:lang="en">The Kimberley, WA Passive Acoustic Observatory, is a series of moorings operated by Curtin University which collect data in the Kimberley region. This observatory was decommissioned in May 2015. </skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-15.483,nominal longitude:121.251,nominal depth:216m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/178"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/179"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/180"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/5"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/905"/>
+	<dcterms:valid xml:lang="en">2012-11-20/2015-05-08</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/905">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Pilbara, WA Passive Acoustic Observatory</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-04-15T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-17T04:56:04Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">PAKIL</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/43"/>
+	<skos:definition xml:lang="en">The Pilbara, WA Passive Acoustic Observatory, is a series of moorings operated by Curtin University which collect data in the Pilbara region. This mooring was decommissioned in June 2015.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-19.388,nominal longitude:115.915,nominal depth:216m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/178"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/179"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/180"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/5"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/904"/>
+	<dcterms:valid xml:lang="en">2012-11-20/2015-06-14</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/908">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Capitaine Fearn</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-05-03T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-07T06:51:30Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">5WDC</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">General Cargo ship vessel. It was called the Forum Samoa II from 2001 until June 2010. It was then shortly called the Opal Harmony, then Southern Moana, and is now known as Capitaine Fearn, and flies the flag of Samoa (July, 2015).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9210713</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2001</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/WSCF/"/>
+	<owl:sameAs rdf:resource="http://vocab.aodn.org.au/def/platform/entity/202"/>
+	<owl:sameAs rdf:resource="http://vocab.aodn.org.au/def/platform/entity/16"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/909">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Shengking</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-05-03T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:54:51Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">9V9713</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Singapore (February 2016)</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9614505</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2013</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/SISH/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/910">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Chenan</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-05-03T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:26:26Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VRUB2</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">General Cargo ship vessel. It was called the Chenan from December 1999 to February 2005, and again from January 2012, and is currently flying the flag of Hong Kong (Feb 2016)</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9007374</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1991</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/HKCH/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/911">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">FluxPulse Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-05-11T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L06) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T05:42:45Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">FluxPulse</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The FluxPulse mooring is operated by CSIRO, and measures biogeochemical properties of the Southern Ocean. It combines the instrumentation from previous separate deployments of the Pulse and SOFS mooring. It had one deployment in April 2016 and was replaced by a SOFS mooring.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-46.77725,nominal longitude:  141.99289,nominal depth:4658m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/181"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/187"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/32"/>
+	<dcterms:valid xml:lang="en">2016-03-01/2016-08-15</dcterms:valid>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/912">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Southern Lily</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-05-12T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-03T00:20:33Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">9VEY2</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel. It was called the Southern Lily in 2011, and is now known as the Southern Trader, which is currently flying the flag of Singapore (Jan, 2015)</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9359674</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2008</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/913">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">ANL Yarrunga</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-05-12T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-03T00:08:25Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">V2BJ5</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which was called the ANL Yarrunga until October 2009. It is now called the Karin Rambow, and is currently flying the flag of Antigua and Barbados (May, 2016)</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9327566</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2005</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/914">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Shearwater</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-07-08T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:54:33Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">3ECT5</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Bulk Carrier vessel, which flew the flag of Panama (September 2010). It was disposed of in ??.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:8508709</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1986</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/PASH/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/915">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Act 10</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-07-08T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-03T00:08:47Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">C6HL</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which was called the Act 10 from 1990 until 1991. It's final name was P and O Nedlloyd Luanda. It was disposed of in 2002.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:7817115</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1980</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/916">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Southern Queen</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-07-08T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-03T00:20:54Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">C6J55</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">General Cargo ship vessel. It was called the Southern Queen from Oct-Dec 2001. It is now called the Red Rock (Indonesia, October 2010).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9197026</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2000</skos:scopeNote>
+	<owl:sameAs rdf:resource="http://vocab.aodn.org.au/def/platform/entity/211"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/917">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Maersk Auckland</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-07-08T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-03T00:15:25Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">A8ES9</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which was known as the Maersk Auckland from February 2003 until July 2007. It was disposed of in 2013.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9236236</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2003</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/918">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">E.R. Wilhelmshaven</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-07-08T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-03T00:12:48Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">ELZY3</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Liberia (May, 2013).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9246310</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2002</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/919">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Maersk Phuket</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-07-08T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:41:39Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">9V3819</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Singapore (July, 2016).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9168219</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1998</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/74IP/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/920">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Southland Star</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-07-08T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:56:19Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">3DTF</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Reefer vessel, which flew the flag of Britain. It was disposed of in 1993.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:6707909</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1967</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/FJSS/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/921">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">California Star</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-07-08T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:24:15Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">C6JF2</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which was known as the Caifornia Star from 1989 until 1996. It's final name was the Golden Gate. It was disposed of in 2009.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:7817103</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1980</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/BACS/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/922">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Vishva Nandin</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-07-26T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:59:12Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">ATSQ</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">General cargo ship vessel, which flew the flag of India. It was disposed of in 1999.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:0000761</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1978</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/41VN/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/923">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Vishva Prafulla</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-07-26T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:59:30Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">ATVB</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">General cargo ship vessel, which flew the flag of India, and was last known as the Asha Manan. It was disposed of in 2009.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:7803425</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1981</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/41VP/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/924">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Bhavabhuti</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-07-26T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T04:50:23Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">ATUF</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">General cargo ship vessel, which flew the flag of India. It was disposed of in 2001.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:7719208</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1981</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/41BB/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/925">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Vishva Parijet</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-07-26T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-03T00:22:43Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">ATVC</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">General cargo ship vessel, which flew the flag of India. It was disposed of in 2000.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:7803401</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1980</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/926">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">CMA CGM Orchid</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-07-26T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:17:57Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">DDLF2</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which flew the flag of Liberia. It is now known as the As Cypria (January, 2011).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9315812</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2006</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/06OR/"/>
+	<owl:sameAs rdf:resource="http://vocab.aodn.org.au/def/platform/entity/221"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/927">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">OOCL Houston</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-09-01T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-13T05:47:04Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VRDE7</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Hong Kong (April, 2016).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9355757</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2007</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/HKHO/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/928">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Swan</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-09-07T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-03-27T22:19:19Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">S6FK</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Reefer ship vessel. It was called the Swan from April 1999 until September 2007. It is now called the Pavlovsk.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:8613542</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1987</skos:scopeNote>
+	<skos:scopeNote xml:lang="en">Replaces http://vocab.aodn.org.au/def/platform/entity/259</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/SISX/"/>
+	<dcterms:replaces xml:lang="en">Swan Reefer (MV Swan)</dcterms:replaces>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/933">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Antarctic Chieftain</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-10-13T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-02T23:31:55Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VJT6415</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/36"/>
+	<skos:definition xml:lang="en">Fishing vessel, currently flying the Australian flag (August 2016).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9262833</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2002</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/934">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Corinthian Bay</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-10-13T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-02T23:32:56Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VJN4779</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/36"/>
+	<skos:definition xml:lang="en">Fishing vessel, currently flying the Australian flag (September 2016).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9188960</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1998</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/935">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Atlas Cove</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-10-13T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-04-02T23:32:32Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VHJT</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/36"/>
+	<skos:definition xml:lang="en">Fishing vessel, currently flying the Australian flag (August 2016).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9171008</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1999</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/99">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Highland Chief</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-05-14T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:37Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VROB</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Hong Kong (May 2013)</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:8809189</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1990</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/096U">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Investigator</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-03-30T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L06) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:45Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VLMJ</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/31"/>
+	<skos:definition xml:lang="en">CSIRO Marine National Facility research vessel. Length 94m.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9616888</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2014; replaces the former CSIRO research vessel: Southern Surveyor (July 2014)</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/09AR">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Aurora Australis</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-04-11T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(P173) Partnership for Observation of the Global Ocean ships of interest</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:38Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VNAA</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/31"/>
+	<skos:definition xml:lang="en">Research vessel owned by P and O Polar, length 94.91m.  Active as at Mar 2013.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:8717283</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1990</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/09SS">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Southern Surveyor</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-04-08T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(P173) Partnership for Observation of the Global Ocean ships of interest</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:30Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VLHJ</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/31"/>
+	<skos:definition xml:lang="en">Was a CSIRO Marine National Facility research vessel. Built 1972 as Ranger Callisto (Norway), then became the UK registered Kurd (1 Jan 1982), then renamed Kurdeen (2 Jan 1982). Renamed Southern Surveyor 31 Dec 1982 and registered in Australia from 15 Nov 1988. Renamed Jupiter in July 2014 (St Kitts and Nevis).  Length 66.16m.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:7113002</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1972</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/33OC">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Oscar Elton Sette</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-07T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L06) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:34Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">WTEE</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/31"/>
+	<skos:definition xml:lang="en">"IMO": "8835097",
+  "title": "NOAA Ship",
+  "country": "United States",
+  "platformclass": "research vessel",
+  "callsign": "WTEE",
+  "pennant": "R 335",
+  "commissioned": "2003-01-23",
+  "previous_name": "Adventurous",
+  "length": "68",
+  "built": "1988-08",
+  "notes": "US NODC WOD code 9315."</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:8835097</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1988</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/353L">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">L'Astrolabe {FHZI}</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-04-08T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(P173) Partnership for Observation of the Global Ocean ships of interest</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-12-11T02:51:26Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">FHZI</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/31"/>
+	<skos:definition xml:lang="en">Research vessel built 1986 as the Canadian vessel Fort Resolution, re-registered in France and renamed Austral Fish 12 May 1988, renamed L'Astrolabe 18 May 1989. Re-registered in French Southern Territories between 20 Jun 1995 - 11 Oct 2006, then re-registered in France. Owned by Bourbon Offshore Surf. Commissioned by TAAF and Institut Polaire Francais Paul-Emile Victor. It was decommissioned in 2017.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:8418198</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1986</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/11">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">fixed benthic node</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-04-08T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L061) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:42Z</dcterms:modified>
+	<skos:definition xml:lang="en">A collection of oceanographic instruments mounted at a fixed position on the seabed (e.g. POL Monitoring Platform seabed ADCP)</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/36"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/12">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">sea bed vehicle</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-10T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L061) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:42Z</dcterms:modified>
+	<skos:definition xml:lang="en">An instrumented platform that is propelled on wheels or tracks on the seabed (e.g benthic crawler).</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/35"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/14">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">land/onshore structure</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-04-08T00:00:00Z</dcterms:created>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/308"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/315"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/322"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/324"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/330"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/334"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L061) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:42Z</dcterms:modified>
+	<skos:definition xml:lang="en">A fixed man-made structure on land to which instrumentation may be attached (e.g. meteorological tower)</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/36"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/16">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">offshore structure</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-07-01T00:00:00Z</dcterms:created>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/309"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/310"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/316"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/317"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/318"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/331"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/332"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/333"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/335"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/336"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/337"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/338"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/339"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/340"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/341"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/342"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L061) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:42Z</dcterms:modified>
+	<skos:definition xml:lang="en">A fixed (for the duration of the measurements) man-made structure away from the coast to which instrumentation may be attached (e.g. oil rig gas rig or jack-up barge)</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/36"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/17">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">coastal structure</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-04-08T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L061) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:42Z</dcterms:modified>
+	<skos:definition xml:lang="en">A fixed man-made structure permanently linked to land with access to water at all states of the tide to which instrumentation may be attached (e.g. pier)</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/36"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/23">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">towed unmanned submersible</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-10T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L061) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:38Z</dcterms:modified>
+	<skos:definition xml:lang="en">A vehicle towed by rigid cable through the water column at fixed or varying depth with no propulsion and no human operator (e.g. Towfish Scanfish UOR SeaSoar)</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/35"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/26">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">lowered unmanned submersible</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-04-08T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L061) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:38Z</dcterms:modified>
+	<skos:definition xml:lang="en">An unmanned platform lowered and raised vertically by a cable from the mothership.  Includes any type of profiling sensor mounting such as CTD frames profiling radiometers and instrumented nets.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/35"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/27">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">sub-surface gliders</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2014-01-20T00:00:00Z</dcterms:created>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/293"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/294"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/295"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L061) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:38Z</dcterms:modified>
+	<skos:definition xml:lang="en">Platforms with buoyancy-based propulsion that are capable of operations of variable depths which are not constrained to be near the sea surface.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/43"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/30">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">ship</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-04-08T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L061) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:39Z</dcterms:modified>
+	<skos:definition xml:lang="en">A large platform operating on the surface of the water column. Objective definitions for guidelines: &gt;50m length (EU) &gt;100 foot length (USA) &gt;300 GRT weight (SOLAS). Subjective definition: a ship is a vessel big enough to carry a boat.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/39"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/31">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">research vessel</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-04-08T00:00:00Z</dcterms:created>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/10"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/109"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/11"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/118"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/12"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/13"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/14"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/17"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/18"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/19"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/273"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/4"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/71"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/72"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/894"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/895"/>
+	<skos:narrower rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/096U"/>
+	<skos:narrower rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/09AR"/>
+	<skos:narrower rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/09SS"/>
+	<skos:narrower rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/33OC"/>
+	<skos:narrower rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/353L"/>
+	<skos:narrower rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/35O7"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L061) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:39Z</dcterms:modified>
+	<skos:definition xml:lang="en">A platform of any size operating on the surface of the water column in unpredictable locations that is specifically equipped manned and operated for scientific usually oceanographic research.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/39"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/32">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">vessel of opportunity</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-04-08T00:00:00Z</dcterms:created>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/1"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/101"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/102"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/103"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/104"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/105"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/106"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/110"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/119"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/199"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/200"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/201"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/202"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/203"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/204"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/205"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/206"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/207"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/208"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/209"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/210"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/211"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/212"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/213"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/214"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/215"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/216"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/217"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/218"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/219"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/220"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/221"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/222"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/223"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/224"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/225"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/226"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/227"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/228"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/229"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/23"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/230"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/231"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/232"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/233"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/234"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/235"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/236"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/238"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/239"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/24"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/240"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/241"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/242"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/243"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/244"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/245"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/246"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/247"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/248"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/249"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/25"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/250"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/252"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/253"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/254"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/255"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/256"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/257"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/258"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/26"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/260"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/261"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/262"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/263"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/264"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/265"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/266"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/267"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/268"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/269"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/27"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/270"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/271"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/272"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/274"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/275"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/277"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/278"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/279"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/28"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/280"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/281"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/282"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/283"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/284"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/285"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/287"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/288"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/289"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/29"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/290"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/291"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/3"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/30"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/31"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/453"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/454"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/455"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/456"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/457"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/458"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/459"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/460"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/461"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/462"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/463"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/464"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/465"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/466"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/467"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/468"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/469"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/470"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/471"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/472"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/473"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/474"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/475"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/890"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/891"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/892"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/908"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/909"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/910"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/912"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/913"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/914"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/915"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/916"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/917"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/918"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/919"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/920"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/921"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/922"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/923"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/924"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/925"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/926"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/927"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/928"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/99"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/16"/>
+	<skos:narrower rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/26JM"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/41"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/43"/>
+	<skos:narrower rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/HK8L"/>
+	<skos:narrower rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/0970"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L061) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:39Z</dcterms:modified>
+	<skos:definition xml:lang="en">A platform for purpose of commerce of any size operating on the surface of the water column in unpredictable locations that regularly collects scientific (oceanographic and meteorological) data (e.g. an instrumented cargo vessel).</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/39"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/33">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">self-propelled small boat</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-10T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L061) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:39Z</dcterms:modified>
+	<skos:definition xml:lang="en">A small self-propelled platform operating on the surface of the water column that may be easily removed from the water (e.g. shore-based RIBs ships' boats).</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/39"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/35">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">vessel of opportunity on fixed route</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-04-08T00:00:00Z</dcterms:created>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/100"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/107"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/108"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/73"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L061) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:38Z</dcterms:modified>
+	<skos:definition xml:lang="en">A platform repeatedly following a predictable fixed track on the surface of the water column that collects scientific (oceanographic and meteorological) data (e.g. an instrumented ferry).</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/39"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/36">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">fishing vessel</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-04-08T00:00:00Z</dcterms:created>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/111"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/112"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/113"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/114"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/115"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/116"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/117"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/15"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/6"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/7"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/8"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/896"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/897"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/9"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/933"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/934"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/935"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L061) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:38Z</dcterms:modified>
+	<skos:definition xml:lang="en">A platform operating on the surface of the water column whose primary purpose is the commercial harevsting of fish or shellfish but may be engaged in scientific activities such as fish stock surveys or mooring deployments and recoveries.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/39"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/37">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">self-propelled boat</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2014-02-21T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L061) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:38Z</dcterms:modified>
+	<skos:definition xml:lang="en">A small self-propelled platform operating on the surface of the water column in unpredictable locations that is smaller than a ship but too large to easily remove from the water.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/39"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/38">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">man-powered boat</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-10T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L061) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:38Z</dcterms:modified>
+	<skos:definition xml:lang="en">A platform operating on the surface of the water column that is manually propelled and may not be easily removed from the water (e.g. trireme).</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/39"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/39">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">naval vessel</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-06T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L06) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:39Z</dcterms:modified>
+	<skos:definition xml:lang="en">A platform operating on the surface of the water column in unpredictable locations that is primarily equipped manned and operated for military purposes.  Includes surface warships of all sizes and logistic support vessels.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/39"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/3A">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">man-powered small boat</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-10T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L061) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:38Z</dcterms:modified>
+	<skos:definition xml:lang="en">A platform operating on the surface of the water column that is manually propelled and may be easily removed from the water (e.g. rowing boat canoe).</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/39"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/41">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">moored surface buoy</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-04-08T00:00:00Z</dcterms:created>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/311"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/312"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/313"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/314"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/319"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/320"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/321"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/323"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/325"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/326"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/327"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/328"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/329"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/343"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/344"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/345"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/346"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/347"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L061) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:36Z</dcterms:modified>
+	<skos:definition xml:lang="en">An unmanned instrumented platform operating on the surface of the water column loosely tethered to the seafloor to maintain a fixed position (e.g. ODAS buoy)</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/44"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/42">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">drifting surface float</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2014-02-26T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L061) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:36Z</dcterms:modified>
+	<skos:definition xml:lang="en">An unmanned instrumented platform operating on the surface of the water column often attached to a drogue to track currents rather than winds (e.g. Argos buoy).</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/37"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/43">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">subsurface mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-04-08T00:00:00Z</dcterms:created>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/143"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/145"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/148"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/151"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/178"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/179"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/180"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/5"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/560"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/561"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/67"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/904"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/905"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L061) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:37Z</dcterms:modified>
+	<skos:definition xml:lang="en">A collection of oceanographic instruments attached to wires suspended between anchors on the seabed and buoyant spheres in the water column.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/44"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/45">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">fixed subsurface vertical profiler</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-10T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L061) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:37Z</dcterms:modified>
+	<skos:definition xml:lang="en">A platform that periodically makes an automated vertical traverse of the water column at a predetermined fixed location. (e.g. YSI vertical profiler HOMER CTD)</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/37"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/46">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">drifting subsurface profiling float</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-04-08T00:00:00Z</dcterms:created>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/296"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/297"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/298"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/299"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/300"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/301"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/302"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/303"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/304"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/305"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/306"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/307"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L061) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:36Z</dcterms:modified>
+	<skos:definition xml:lang="en">An unmanned instrumented platform drifting freely in the water column that periodically makes vertical traverses through the water column (e.g. Argo float)</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/37"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/48">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-04-08T00:00:00Z</dcterms:created>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/163"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/120"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/121"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/122"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/123"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/124"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/125"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/126"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/127"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/128"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/129"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/130"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/131"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/132"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/133"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/134"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/135"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/136"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/137"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/138"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/139"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/140"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/141"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/142"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/144"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/146"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/147"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/149"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/150"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/152"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/153"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/154"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/155"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/156"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/157"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/158"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/159"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/160"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/161"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/162"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/164"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/165"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/166"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/167"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/168"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/169"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/170"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/171"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/172"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/173"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/174"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/175"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/176"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/177"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/181"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/187"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/188"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/189"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/190"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/191"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/192"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/193"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/194"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/195"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/196"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/197"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/198"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/2"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/20"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/21"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/22"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/32"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/33"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/34"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/35"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/36"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/37"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/38"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/65"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/66"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/68"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/69"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/898"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/899"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/900"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/901"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/902"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/903"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/911"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/40"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L061) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-06-26T23:24:36Z</dcterms:modified>
+	<skos:definition xml:lang="en">A tethered collection of oceanographic instruments at a fixed location that may include seafloor mid-water and surface components.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/44"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/64">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">geostationary orbiting satellite</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-04-08T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L061) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:45Z</dcterms:modified>
+	<skos:definition xml:lang="en">A vehicle operating beyond the Earth's atmosphere without human occupants that orbits the Earth at the same rate as the Earth's rotation keeping it over a fixed location on the Earth's surface..</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/41"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/65">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">orbiting satellite</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-04-08T00:00:00Z</dcterms:created>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/863"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/864"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/865"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/866"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/867"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/868"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/869"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/870"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/871"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/872"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/873"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/874"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/879"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/881"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/882"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/883"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/884"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/885"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/886"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/887"/>
+	<skos:narrower rdf:resource="http://vocab.aodn.org.au/def/platform/entity/42"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L061) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:45Z</dcterms:modified>
+	<skos:definition xml:lang="en">A vehicle operating beyond the Earth's atmosphere without human occupants that orbits the Earth at a different rate to the Earth's rotation so it moves over the Earth's surface..</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/41"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/70">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">organism</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2014-01-22T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L061) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:45Z</dcterms:modified>
+	<skos:definition xml:lang="en">A living creature carrying instruments or collecting samples</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/40"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/72">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">diver</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-10T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L061) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:45Z</dcterms:modified>
+	<skos:definition xml:lang="en">A human being with self-contained equipment or surface-connected suit enabling operation within the water column.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/40"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/73">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">flightless bird</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-04-08T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L061) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:45Z</dcterms:modified>
+	<skos:definition xml:lang="en">A bird that is unable to fly with the ability to exist within the water column (e.g. penguin).</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/40"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/74">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">seabird and duck</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2014-01-16T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L061) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:45Z</dcterms:modified>
+	<skos:definition xml:lang="en">A flighted bird that is able to exist on the water column surface and dive into the water column (e.g. cormorants auks ducks and gulls).</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/40"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/77">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">land-sea mammals</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-04-08T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L061) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-07T03:52:46Z</dcterms:modified>
+	<skos:definition xml:lang="en">A mammal that exists both on land and within the water column. Includes seals sealions sea-otters and walruses.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/40"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#ConceptScheme">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#hasTopConcept">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#hasTopConcept"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/61">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">research aeroplane</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-06-27T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L06) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-07-03T06:28:26Z</dcterms:modified>
+	<skos:definition xml:lang="en">A fixed-wing self-propelled aircraft that is equipped manned and operated for atmospheric meteorological or oceanographic research.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/2"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/62">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">aeroplane</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-06-27T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L06) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-07-03T06:28:17Z</dcterms:modified>
+	<skos:definition xml:lang="en">A fixed-wing self-propelled aircraft.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/2"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/67">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">helicopter</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-06-27T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L06) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-07-03T06:28:30Z</dcterms:modified>
+	<skos:definition xml:lang="en">An aircraft without wings that obtains its lift from the rotation of overhead blades.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/2"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/6A">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">glider</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-06-27T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L06) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-07-03T06:28:37Z</dcterms:modified>
+	<skos:definition xml:lang="en">A fixed-wing aircraft with no propulsion.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/2"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/71">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">human</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-06-27T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L06) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-07-03T05:46:35Z</dcterms:modified>
+	<skos:definition xml:lang="en">A human being without specialised equipment operating on land or the surface of the water column.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/40"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/75">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">cetacean</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-06-27T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L06) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-07-03T05:46:45Z</dcterms:modified>
+	<skos:definition xml:lang="en">A mammal that exists within the water column but needing to regularly surface to breathe (i.e. dolphins and whales).</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/40"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/76">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">fish</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-06-27T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L06) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-07-03T05:46:49Z</dcterms:modified>
+	<skos:definition xml:lang="en">A free-swimming creature that exists totally within the water column.</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:broadMatch rdf:resource="http://vocab.aodn.org.au/def/platform_classes/category/40"/>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/elements/1.1/publisher">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://purl.org/dc/elements/1.1/publisher"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/elements/1.1/source">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://purl.org/dc/elements/1.1/source"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://editor.vocabs.ands.org.au/user/Sebastien_Mancini">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://purl.org/dc/terms/Agent"/>
+	<foaf:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sebastien_Mancini</foaf:name>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/terms/modified">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/modified"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#Concept">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#altLabel">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#broader">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#broader"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#definition">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#hiddenLabel">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#hiddenLabel"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#inScheme">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#inScheme"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#scopeNote">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#scopeNote"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://purl.org/dc/terms/Agent"/>
+	<foaf:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMII_Atkins.Natalia</foaf:name>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#related">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#related"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#exactMatch">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#exactMatch"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/BH1S/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/0956/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/HKPB/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/090C/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/61TN/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/09UK/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/29HE/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/MHV4/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/35MV/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/40">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Coffs Harbour 50m Mooring</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-12-13T02:40:52Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-14T05:16:18Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">CH050</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/48"/>
+	<skos:definition xml:lang="en">The Coffs Harbour 50m Mooring is operated by SIMS (Sydney Institute of Marine Science) and collects data in the Coffs Harbour region.
+</skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">nominal latitude:-30.311,nominal longitude:153.231,nominal depth:50m</skos:scopeNote>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/120"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/121"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/122"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/123"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/165"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/166"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/177"/>
+	<skos:related rdf:resource="http://vocab.aodn.org.au/def/platform/entity/20"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/terms/valid">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/valid"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/318M/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/49NZ/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/PAJB/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://editor.vocabs.ands.org.au/user/Natalia_Atkins">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://purl.org/dc/terms/Agent"/>
+	<foaf:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Natalia_Atkins</foaf:name>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/CYAF/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2002/07/owl#sameAs">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#sameAs"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/WSFS/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/SISR/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/SIAD/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/TNCT/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/TNSM/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/54BO/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/54CR/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/54MI/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/54ME/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/54PS/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/54A6/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/54CQ/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/BHBS/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/06WM/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/06CZ/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/06SD/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/06AT/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/06EC/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/54OT/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/74B8/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/74FG/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/74B7/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/74D9/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/BHAJ/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/SIW6/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/74WB/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/32PZ/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/5438/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/11LY/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/64NW/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/64NX/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/64RB/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/AGRI/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/AGFL/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/AGVG/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/AGRG/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/AGKK/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/09DA/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/09AH/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/09NC/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/09IK/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/09PC/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/09FA/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/09FD/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/09AU/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/74HZ/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/74HX/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/HKPC/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/74I3/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/74AS/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/747X/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/61LY/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/PATI/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/SIOX/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/54AO/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/54LB/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/54CM/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/54CW/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/06M7/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/06CE/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/58SM/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/58EN/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/CYCS/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/64AD/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/AGMF/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/AGSD/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/AGSF/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/HKSE/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/HKME/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/VUPG/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/BMMX/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/097H/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/09CX/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#broadMatch">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#broadMatch"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform_classes/category/42">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#topConceptOf">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#topConceptOf"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://editor.vocabs.ands.org.au/user/superadmin">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://purl.org/dc/terms/Agent"/>
+	<foaf:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">superadmin</foaf:name>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/09TF/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform_classes/category/39">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/SIVG/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/CY4W/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/SIWU/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/CIFR/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/WSCF/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/SISH/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/HKCH/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/PASH/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/74IP/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/FJSS/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/BACS/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/41VN/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/41VP/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/41BB/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/06OR/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/HKHO/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/SISX/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/terms/replaces">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/replaces"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform_classes/category/36">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform_classes/category/35">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform_classes/category/43">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform_classes/category/44">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform_classes/category/37">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform_classes/2">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform_classes/category/41">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform_classes/category/40">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/16">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Capitaine Quiros</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-07T06:48:35Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-03-27T21:42:50Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">9V3505</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Cargo ship vessel. It was called the Forum Samoa II from 2001 until June 2010. It was then shortly called the Opal Harmony, then Southern Moana, then Capitaine Fearn. It currently flies the flag of Singapore (2018).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9210713</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2001
+</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/SICJ/"/>
+	<owl:sameAs rdf:resource="http://vocab.aodn.org.au/def/platform/entity/202"/>
+	<owl:sameAs rdf:resource="http://vocab.aodn.org.au/def/platform/entity/908"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/35O7">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">L'Astrolabe {FASB}</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-12-11T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L06) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-03-27T23:11:39Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">FASB</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/31"/>
+	<skos:definition xml:lang="en">The Astrolabe is a research vessel which is an icebreaker (Class IB5 of the Polar Code), built in 2017 as part of a partnership between the French Southern and Antarctic Territories (TAAF), the French Polar Institute Paul-Emile Victor (IPEV) and the Ministry of Defense (National Navy (MN)). The partnership is made through the creation of a public interest grouping between the TAAF and the MN and an agreement between the MN and the IPEV.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9797539</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2017</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/platform/1">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/26JM">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Josephine Maersk</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-02-20T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L06) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-03-27T23:12:38Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">OWKF2</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Denmark (September 2016).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9215191</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2002</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/41">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">ANL Elaroo</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-02-08T02:46:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-03-27T21:37:18Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">D5BG5</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Liberia (January 2019).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9516777</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2012</skos:scopeNote>
+	<skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/collection/C17/current/54R6/"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/SICJ/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/11AE/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/0926/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/42">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">SNPP</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-02-15T03:41:10Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network Platform Register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-02-15T03:54:11Z</dcterms:modified>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/65"/>
+	<skos:definition xml:lang="en">This satellite was a prototype of the JPSS programme, originally designed as Preparatory Programme of the aborted NPOESS (National Polar-orbiting Operational Environmental Satellite System). It operated from October 2011, at an altitute of 825km, in a sunsynchronous orbit. Instrumentation: Advanced Technology Microwave Sounder, Clouds and the Earth’s Radiant Energy System, Cross-track Infrared Sounder, Ozone Mapping and Profiler Suite, and Visible/Infrared Imager Radiometer Suite. </skos:definition>
+	<skos:hiddenLabel xml:lang="en">Suomi National Polar-orbiting Partnership</skos:hiddenLabel>
+	<skos:hiddenLabel xml:lang="en">NASA/NOAA - Joint Polar Satellite System (JPSS) - SNPP</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/54R6/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/43">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">HMB Endeavour</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-03-26T05:08:01Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network platform register</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-03-26T05:13:47Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VNJC</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Passenger ship vessel, which is currently flying the flag of Australia (February, 2019). 
+</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:8644967</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1994
+</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/09WX/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/09B1/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/HK8L">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">OOCL Texas</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-03-28T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L06) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-03-27T23:12:59Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VRDP4</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">Container ship vessel, which is currently flying the flag of Hong Kong (January, 2019).</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:9329552</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:2008</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/0970">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="en">Northwest Sandpiper</skos:prefLabel>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/eMII_Atkins.Natalia"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-03-28T00:00:00Z</dcterms:created>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">British Oceanographic Data Centre (BODC)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(L06) SeaVoX Platform Categories</dc:source>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-03-27T23:12:49Z</dcterms:modified>
+	<skos:altLabel xml:lang="en">VNVG</skos:altLabel>
+	<skos:broader rdf:resource="http://vocab.nerc.ac.uk/collection/L06/current/32"/>
+	<skos:definition xml:lang="en">LNG Tanker vessel, which is currently flying the flag of Australia.</skos:definition>
+	<skos:hiddenLabel xml:lang="en">IMO:8913150</skos:hiddenLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/platform/1"/>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/platform/1"/>
+	<skos:scopeNote xml:lang="en">built:1993</skos:scopeNote>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/863/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">NOAA-8</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2002/07/owl#deprecated">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#deprecated"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/864/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">NOAA-9</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/865/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">NOAA-10</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/866/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">NOAA-11</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/867/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">NOAA-12</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/868/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">NOAA-13</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/869/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">NOAA-14</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/870/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">NOAA-15</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/871/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">NOAA-16</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/872/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">NOAA-17</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/873/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">NOAA-18</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/874/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">NOAA-19</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/879/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">Aqua</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/881/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">OrbView-2</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/882/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">SAC-D</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/883/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">TOPEX-Poseidon</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/884/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">JASON-1</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/885/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">JASON-2</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/886/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">JASON-3</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/887/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">GFO</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/890">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">Maersk Jalan</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/891">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">Patricia Schulte</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/892">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">Siangtan</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/894">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">Ramform Sovereign</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/895">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">Falkor</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/896">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">Isla Eden</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/897">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">Saxon Onward</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/898">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">Wistari Channel Acidification Mooring</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/899">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">Yongala National Reference Station Acidification Mooring</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/900">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">TOTTEN1 Mooring</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/901">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">TOTTEN2 Mooring</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/902">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">TOTTEN3 Mooring</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/903">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">Two Rocks 44m Shelf Mooring</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/904">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">Kimberley, WA Passive Acoustic Observatory</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/905">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">Pilbara, WA Passive Acoustic Observatory</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/906">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">Pulse 9 Mooring</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/907">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">Pulse 10 Mooring</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/182">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">Pulse 5 'heavy' Mooring</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/183">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">Pulse 5 'light' Mooring</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/184">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">Pulse 6 Mooring</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/185">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">Pulse 7 Mooring</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/186">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">Pulse 8 Mooring</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/259">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">Swan Reefer (MV Swan)</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/906">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">Pulse 9 Mooring</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/platform/entity/907">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">Pulse 10 Mooring</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/C17/current/33OC/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">Oscar Elton Sette</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.nerc.ac.uk/collection/L06/current/39/">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">naval vessel</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/terms/Agent">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subClassOf rdf:resource="http://purl.org/dc/terms/Agent"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://xmlns.com/foaf/0.1/name">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://xmlns.com/foaf/0.1/name"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/terms/issued">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/issued"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2002/07/owl#versionInfo">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#versionInfo"/>
+</rdf:Description>
+
+</rdf:RDF>

--- a/test_aodndata/vocab/aodn_aodn-xbt-line-vocabulary.rdf
+++ b/test_aodndata/vocab/aodn_aodn-xbt-line-vocabulary.rdf
@@ -1,0 +1,2397 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:owl="http://www.w3.org/2002/07/owl#"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+	xmlns:fn="http://www.w3.org/2005/xpath-functions#"
+	xmlns:dcterms="http://purl.org/dc/terms/"
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+	xmlns:sesame="http://www.openrdf.org/schema/sesame#"
+	xmlns:foaf="http://xmlns.com/foaf/0.1/"
+	xmlns:cycAnnot="http://sw.cyc.com/CycAnnotations_v1#"
+	xmlns:csw="http://semantic-web.at/ontologies/csw.owl#"
+	xmlns:freebase="http://rdf.freebase.com/ns/"
+	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+	xmlns:dbpedia="http://dbpedia.org/resource/"
+	xmlns:cyc="http://sw.cyc.com/concept/"
+	xmlns:tags="http://www.holygoat.co.uk/owl/redwood/0.1/tags/"
+	xmlns:opencyc="http://sw.opencyc.org/concept/"
+	xmlns:ctag="http://commontag.org/ns#"
+	xmlns:dc="http://purl.org/dc/elements/1.1/">
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#subject">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#subject"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#object">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#object"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#first">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#first"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#rest">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+	<rdfs:range rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#rest"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#value">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#value"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#List">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#domain">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#domain"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#Resource">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#range">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#range"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#subPropertyOf">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdfs:range rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#subPropertyOf"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#subClassOf">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#Class">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#member">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#member"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#seeAlso">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#seeAlso"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#isDefinedBy">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#seeAlso"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#isDefinedBy"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#comment">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#comment"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#label">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:domain rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#Literal">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#Alt">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Alt"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Container"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#Container">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Container"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#Bag">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Container"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Bag"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#Seq">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Container"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Seq"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#ContainerMembershipProperty">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#ContainerMembershipProperty"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Datatype"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#Datatype">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Datatype"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://editor.vocabs.ands.org.au/user/eMII_Finney.Kim_Admin">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://purl.org/dc/terms/Agent"/>
+	<foaf:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMII_Finney.Kim_Admin</foaf:name>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/terms/Agent">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subClassOf rdf:resource="http://purl.org/dc/terms/Agent"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://xmlns.com/foaf/0.1/name">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://xmlns.com/foaf/0.1/name"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://purl.org/dc/terms/Agent"/>
+	<foaf:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sebastien Mancini</foaf:name>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://editor.vocabs.ands.org.au/user/eMII">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://purl.org/dc/terms/Agent"/>
+	<foaf:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMII</foaf:name>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://editor.vocabs.ands.org.au/user/eMarine-Information-Infrastructure-eMII">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://purl.org/dc/terms/Agent"/>
+	<foaf:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</foaf:name>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/65">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:label xml:lang="en">Testobject</rdfs:label>
+	<owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2002/07/owl#deprecated">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#deprecated"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/1">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+	<dc:rights rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Freely Available For Reuse</dc:rights>
+	<dcterms:contributor rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dcterms:description xml:lang="en">This register contains a controlled vocabulary for XBT lines.</dcterms:description>
+	<dcterms:publisher rdf:resource="http://editor.vocabs.ands.org.au/user/eMarine-Information-Infrastructure-eMII"/>
+	<dcterms:subject xml:lang="en">xbtline</dcterms:subject>
+	<dcterms:title xml:lang="en">XBT line vocabulary</dcterms:title>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/1"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/10"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/100"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/101"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/102"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/103"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/104"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/105"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/106"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/107"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/108"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/109"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/11"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/110"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/111"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/112"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/113"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/114"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/115"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/116"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/117"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/118"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/119"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/12"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/120"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/121"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/122"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/123"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/124"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/125"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/126"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/127"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/128"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/129"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/13"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/130"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/131"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/132"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/133"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/134"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/135"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/14"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/15"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/16"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/17"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/18"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/19"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/2"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/20"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/21"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/22"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/23"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/24"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/25"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/26"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/27"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/28"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/29"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/3"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/30"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/31"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/32"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/33"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/34"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/35"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/36"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/37"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/38"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/39"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/4"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/40"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/41"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/42"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/43"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/44"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/45"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/46"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/47"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/48"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/49"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/5"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/50"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/51"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/52"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/53"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/54"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/55"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/56"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/57"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/58"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/59"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/6"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/60"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/61"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/62"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/63"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/64"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/66"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/67"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/68"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/69"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/7"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/70"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/71"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/72"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/73"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/74"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/75"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/76"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/77"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/78"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/79"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/8"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/80"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/81"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/82"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/83"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/84"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/85"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/86"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/87"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/88"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/89"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/9"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/90"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/91"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/92"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/93"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/94"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/95"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/96"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/97"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/98"/>
+	<skos:hasTopConcept rdf:resource="http://vocab.aodn.org.au/def/xbtline/entity/99"/>
+	<dcterms:identifier xml:lang="en">entity</dcterms:identifier>
+	<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-02-27T22:28:07Z</dcterms:modified>
+	<dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2017-02-28</dcterms:issued>
+	<owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Version 1.0</owl:versionInfo>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/elements/1.1/rights">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://purl.org/dc/elements/1.1/rights"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/terms/contributor">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/contributor"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/terms/created">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/created"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/terms/creator">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/creator"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/terms/description">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/description"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/terms/publisher">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/publisher"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/terms/subject">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/subject"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/terms/title">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/title"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#ConceptScheme">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#hasTopConcept">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#hasTopConcept"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/1">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Greenland - Iceland - Denmark</skos:altLabel>
+	<skos:altLabel xml:lang="en">Greenland - Iceland - Ireland</skos:altLabel>
+	<skos:altLabel xml:lang="en">Greenland - Iceland - Scotland</skos:altLabel>
+	<skos:definition xml:lang="en"></skos:definition>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">AX01</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/10">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">New York - Caracas</skos:altLabel>
+	<skos:altLabel xml:lang="en">New York - Trinidad</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">AX10</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/100">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Tahiti - Auckland</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX28</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/101">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Tahiti - Valparaiso</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX29</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/102">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Brisbane - Noumea - Fiji</skos:altLabel>
+	<skos:altLabel xml:lang="en">Brisbane - Noumea - Lautoka</skos:altLabel>
+	<skos:altLabel xml:lang="en">Brisbane - Noumea - Suva</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX30</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<code xmlns="http://imos.org.au/def/xbt/" xml:lang="en">PX30-31</code>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/103">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Fiji - California</skos:altLabel>
+	<skos:altLabel xml:lang="en">Noumea - Fiji</skos:altLabel>
+	<skos:altLabel xml:lang="en">Noumea - Fiji - California</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX31</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/104">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Sydney - Auckland</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX32</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/105">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Hobart - Macquarie Island</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX33</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/106">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Sydney - Wellington</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX34</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<georssline xmlns="http://www.georss.org/" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">151.3483 -33.84711 172.84103 -40.25969</georssline>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/107">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Melbourne - Dunedin</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX35</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/108">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Christchurch - McMurdo</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX36</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/109">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Hawaii - California</skos:altLabel>
+	<skos:altLabel xml:lang="en">Hawaii - San Francisco</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX37</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/11">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Europe - Brazil</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">AX11</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/110">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Hawaii - California</skos:altLabel>
+	<skos:altLabel xml:lang="en">Hawaii - Long Beach</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX37-South</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/111">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Hawaii - Alaska</skos:altLabel>
+	<skos:altLabel xml:lang="en">Hawaii - Kodiak</skos:altLabel>
+	<skos:altLabel xml:lang="en">Hawaii - Valdez</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX38</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/112">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Hawaii - Seattle</skos:altLabel>
+	<skos:altLabel xml:lang="en">Hawaii - Vancouver</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX39</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/113">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Hawaii - Yokohama</skos:altLabel>
+	<skos:altLabel xml:lang="en">Japan - Hawaii</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX40</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/114">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Hawaii - Hong Kong</skos:altLabel>
+	<skos:altLabel xml:lang="en">Hawaii - Taiwan</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX41</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/115">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Hawaii - New Guinea</skos:altLabel>
+	<skos:altLabel xml:lang="en">Hawaii - Solomon Islands</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX42</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/116">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Hawaii - Marshall Islands - Guam</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX43</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/117">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Hong Kong - Guam</skos:altLabel>
+	<skos:altLabel xml:lang="en">Taiwan - Guam</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX44</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/118">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">(3N,137E) - (34N,137E)</skos:altLabel>
+	<skos:altLabel xml:lang="en">137th meridian east from 3N to 34N</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX45</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/119">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">(3S,165E) - (50N,1165E)</skos:altLabel>
+	<skos:altLabel xml:lang="en">165th meridian east from 3S to 50N</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX46</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/12">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Europe - Antarctica</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">AX12</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/120">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Alaska - California</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX47</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/121">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Japan - Singapore</skos:altLabel>
+	<skos:altLabel xml:lang="en">Taiwan - Singapore</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX49</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/122">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Valparaiso - Auckland</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX50</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/123">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Hong Kong - Auckland</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX51</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/124">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Japan - Fiji</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX52</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/125">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Mindanao - Fiji</skos:altLabel>
+	<skos:altLabel xml:lang="en">Taiwan - Fiji</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX53</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/126">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Melbourne - Wellington</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX55</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/127">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Brisbane - Dunedin</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX56</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/128">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Brisbane - Wellington</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX57</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/129">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Costa Rica coast</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX76</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/13">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Brazil - Liberia</skos:altLabel>
+	<skos:altLabel xml:lang="en">Rio de Janeiro - Monrovia</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">AX13</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/130">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Peru coastal</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX77</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/131">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Valparaiso - 80W</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX79</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/132">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Tahiti - Cape Horn</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX80</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/133">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Hawaii - Chile</skos:altLabel>
+	<skos:altLabel xml:lang="en">Honolulu - Coronel</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX81</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/134">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Melbourne - Fiji</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX82</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/135">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Melbourne - Auckland</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX83</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/14">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Brazil - Nigeria</skos:altLabel>
+	<skos:altLabel xml:lang="en">Rio de Janeiro - Lagos</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">AX14</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/15">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Europe - Cape of Good Hope</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">AX15</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/16">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Brazil - Namibia</skos:altLabel>
+	<skos:altLabel xml:lang="en">Rio de Janeiro - Walvis Bay</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">AX16</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/17">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Rio de Janeiro - Cape of Good Hope</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">AX17</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/18">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Buenos Aires - Cape of Good Hope</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">AX18</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/19">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Cape Horn - Cape of Good Hope</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">AX19</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/2">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Newfoundland - Iceland</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">AX02</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/20">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Europe - French Guyana</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">AX20</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/21">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Cape Verde - Belem</skos:altLabel>
+	<skos:altLabel xml:lang="en">Cape Verde - Brazil</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">AX20b</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/22">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Rio de Janeiro - Luanda</skos:altLabel>
+	<skos:altLabel xml:lang="en">Rio de Janeiro - Pointe Noire</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">AX21</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/23">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Drake Passage</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">AX22</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/24">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Gulf of Mexico</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">AX23</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/25">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Cape Town - Antarctica</skos:altLabel>
+	<skos:altLabel xml:lang="en">Cape of Good Hope - Antarctica</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">AX25</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/26">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Cape of Good Hope - Lagos</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">AX26</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/27">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Brazil - Cape Horn</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">AX27</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/28">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">New York - Brazil</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">AX29</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/29">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">New York - Bermuda</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">AX32</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/3">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Europe - New York</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">AX03</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/30">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Boston - Halifax</skos:altLabel>
+	<skos:altLabel xml:lang="en">Boston - Nova Scotia</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">AX33</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/31">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Gulf of Guinea - Caribbean</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">AX34</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/32">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Cape of Good Hope - Recife</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">AX35</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/33">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Cape Horn - Gulf of Guinea</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">AX36</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/34">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Rio de Janeiro - Trindade island</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">AX97</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/35">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Norwegian Sea</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">AX98</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/36">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Southern Ocean</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">AX99</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<code xmlns="http://imos.org.au/def/xbt/" xml:lang="en">SO</code>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/37">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Fremantle - Sunda Strait</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">IX01</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<code xmlns="http://imos.org.au/def/xbt/" xml:lang="en">IX1</code>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/38">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Cape of Good Hope - Fremantle</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">IX02</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<code xmlns="http://imos.org.au/def/xbt/" xml:lang="en">IX2</code>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/39">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Red Sea - La Reunion</skos:altLabel>
+	<skos:altLabel xml:lang="en">Red Sea - Mauritius</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">IX03</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/4">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">New York - Gibraltar</skos:altLabel>
+	<skos:altLabel xml:lang="en">New York - Lisbon</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">AX04</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/40">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">La Reunion - Malacca Strait</skos:altLabel>
+	<skos:altLabel xml:lang="en">Mauritius - Malacca Strait</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">IX06</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/41">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Cape of Good Hope - Persian Gulf</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">IX07</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/42">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Mauritius - Bombay</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">IX08</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<code xmlns="http://imos.org.au/def/xbt/" xml:lang="en">IX8</code>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/43">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Fremantle - Persian Gulf</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">IX09</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<code xmlns="http://imos.org.au/def/xbt/" xml:lang="en">IX9</code>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/44">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Sri Lanka - Persian Gulf</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">IX09-North</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/45">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Red Sea - Malacca Strait</skos:altLabel>
+	<skos:altLabel xml:lang="en">Red Sea - Singapore</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">IX10</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/46">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Calcutta - Java Sea</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">IX11</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/47">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Fremantle - Red Sea</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">IX12</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/48">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Bay of Bengal</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">IX14</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/49">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Mauritius - Fremantle</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">IX15</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/5">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Europe - Panama Canal</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">AX05</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/50">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Mombassa - Singapore</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">IX16</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/51">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Mombassa - Karachi</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">IX17</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/52">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Mombassa - Bombay</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">IX18</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/53">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">La Reunion - Kerguelen</skos:altLabel>
+	<skos:altLabel xml:lang="en">Mauritius - Kerguelen</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">IX19</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/54">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">La Reunion - Amsterdam</skos:altLabel>
+	<skos:altLabel xml:lang="en">Mauritius - Amsterdam</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">IX19b</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/55">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Mauritius - Rodriguez</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">IX20</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/56">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Cape of Good Hope - Mauritius</skos:altLabel>
+	<skos:altLabel xml:lang="en">Durban - Mauritius</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">IX21</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/57">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Shark Bay - Banda Sea</skos:altLabel>
+	<skos:altLabel xml:lang="en">Shark Bay - Timor Strait</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">IX22</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/58">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Port Hedland - Japan</skos:altLabel>
+	<skos:altLabel xml:lang="en">Shark Bay - Japan</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">IX22-PX11</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/59">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Hobart - Casey station</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">IX23</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/6">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">New York - Abidjan</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">AX06</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/60">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Mauritius - Karachi</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">IX25</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/61">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Red Sea - Karachi</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">IX26</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/62">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Mombassa - La Reunion</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">IX27</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/63">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Hobart - Dumont d'Urville</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">IX28</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/64">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Macquarie Island - Casey station</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">IX29</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/66">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Melbourne - Point Leeuwin</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">IX31</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/67">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Haifa - Gibraltar</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">MX01</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/68">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Barcelona - Skikda</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">MX02</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/69">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Sete - Tunis</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">MX03</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/7">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Gulf of Mexico - Abidjan</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">AX07</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/70">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Genoa - Palermo</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">MX04</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/71">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Malta - Trieste</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">MX05</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/72">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Alexandria - Crete - Tessaloniki</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">MX06</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/73">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Cyprus - Port Said</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">MX07</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/74">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Seattle - Indonesia</skos:altLabel>
+	<skos:altLabel xml:lang="en">Vancouver - Indonesia</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX01</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/75">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Flores Sea - Torres Strait</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX02</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<code xmlns="http://imos.org.au/def/xbt/" xml:lang="en">PX2</code>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/76">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Coral Sea</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX03</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/77">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Japan - Kiribati - Fiji</skos:altLabel>
+	<skos:altLabel xml:lang="en">Japan - Kiribati - Samoa</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX04</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/78">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Japan - New Zealand</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX05</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/79">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Brisbane - Yokohama</skos:altLabel>
+	<skos:altLabel xml:lang="en">Japan - Australia</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX05b</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/8">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">New York - Cape of Good Hope</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">AX08</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/80">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Auckland - Suva</skos:altLabel>
+	<skos:altLabel xml:lang="en">New Zealand - Fiji</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX06</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/81">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Auckland - Panama</skos:altLabel>
+	<skos:altLabel xml:lang="en">Dunedin - Panama</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX08</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/82">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Hawaii - Auckland</skos:altLabel>
+	<skos:altLabel xml:lang="en">Hawaii - Fiji</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX09</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/83">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Guam - Hawaii</skos:altLabel>
+	<skos:altLabel xml:lang="en">Saipan - Hawaii</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX10</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/84">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Flores Sea - Japan</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX11</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/85">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Tahiti - Noumea</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX12</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/86">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">New Zealand - California</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX13</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/87">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Alaska - Cape Horn</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX14</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/88">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Ecuador - Japan</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX15</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/89">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Hawaii - Peru</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX16</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/9">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Caracas - Gibraltar</skos:altLabel>
+	<skos:altLabel xml:lang="en">Trinidad - Gibraltar</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">AX09</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/90">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Maruroa - Panama</skos:altLabel>
+	<skos:altLabel xml:lang="en">Tahiti - Panama</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX17</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/91">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Tahiti - California</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX18</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/92">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">California - Panama</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX20</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/93">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">California - Chile</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX21</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/94">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Panama - Valparaiso</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX22</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/95">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Panama - 115W</skos:altLabel>
+	<skos:altLabel xml:lang="en">Panama - 115th meridian west</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX23</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/96">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Panama - Indonesia</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX24</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/97">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Valparaiso - Japan</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX25</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/98">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">TRANSPAC</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX26</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://vocab.aodn.org.au/def/xbtline/entity/99">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T00:00:00Z</dcterms:created>
+	<dcterms:creator rdf:resource="http://editor.vocabs.ands.org.au/user/Sebastien-Mancini"/>
+	<dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eMarine Information Infrastructure (eMII)</dc:publisher>
+	<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Australian Ocean Data Network XBT line register</dc:source>
+	<skos:altLabel xml:lang="en">Guayaquil - Galapagos</skos:altLabel>
+	<skos:inScheme rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+	<skos:prefLabel xml:lang="en">PX27</skos:prefLabel>
+	<skos:topConceptOf rdf:resource="http://vocab.aodn.org.au/def/xbtline/1"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/elements/1.1/publisher">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://purl.org/dc/elements/1.1/publisher"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/elements/1.1/source">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://purl.org/dc/elements/1.1/source"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#Concept">
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subClassOf rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#altLabel">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#definition">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#inScheme">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#inScheme"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#prefLabel">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#prefLabel"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#topConceptOf">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#topConceptOf"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://imos.org.au/def/xbt/code">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://imos.org.au/def/xbt/code"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.georss.org/georssline">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.georss.org/georssline"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/terms/identifier">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/identifier"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/terms/modified">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/modified"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://purl.org/dc/terms/issued">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/issued"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.w3.org/2002/07/owl#versionInfo">
+	<rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+	<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+	<rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#versionInfo"/>
+</rdf:Description>
+
+</rdf:RDF>

--- a/test_aodndata/vocab/test_platform_code_vocab.py
+++ b/test_aodndata/vocab/test_platform_code_vocab.py
@@ -1,0 +1,55 @@
+import os
+from unittest.mock import patch
+
+from aodncore.pipeline import HandlerBase
+from aodncore.testlib import BaseTestCase, HandlerTestCase
+from aodndata.vocab.platform_code_vocab import (PlatformVocabHelper, platform_type_uris_by_category,
+                                                platform_altlabels_per_preflabel)
+
+TEST_ROOT = os.path.join(os.path.dirname(__file__))
+
+TEST_PLATFORM_CAT_VOCAB_URL = '%s%s' % ('file://',
+                                        os.path.join(TEST_ROOT, 'aodn_aodn-platform-category-vocabulary.rdf'))
+
+TEST_PLATFORM_VOCAB_URL = '%s%s' % ('file://',
+                                    os.path.join(TEST_ROOT, 'aodn_aodn-platform-vocabulary.rdf'))
+
+
+class TestVocabHandler(HandlerBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.platform_vocab_helper = PlatformVocabHelper(TEST_PLATFORM_VOCAB_URL, TEST_PLATFORM_CAT_VOCAB_URL)
+
+
+class TestDummyHandler(HandlerTestCase):
+    def setUp(self):
+        self.handler_class = TestVocabHandler
+        super().setUp()
+
+    def test_platform_vocab_helper(self):
+        handler = self.handler_class(self.temp_nc_file)
+        self.assertIsInstance(handler.platform_vocab_helper.platform_type_uris_by_category(), dict)
+        self.assertEqual(handler.platform_vocab_helper.platform_altlabels_per_preflabel('Vessel')['9VUU'], 'Anro Asia')
+
+
+
+class TestPlatformCodeVocab(BaseTestCase):
+    def setUp(self):
+        self.platform_vocab_helper = PlatformVocabHelper(TEST_PLATFORM_VOCAB_URL, TEST_PLATFORM_CAT_VOCAB_URL)
+
+    def test_platform_type(self):
+        res = self.platform_vocab_helper.platform_type_uris_by_category()
+        self.assertEqual(res['Float'][0], 'http://vocab.nerc.ac.uk/collection/L06/current/42')
+
+    def test_altlabels(self):
+        res = self.platform_vocab_helper.platform_altlabels_per_preflabel(category_name='Vessel')
+        self.assertEqual(res['9VUU'], 'Anro Asia')
+
+    def test_platform_type_deprecated(self):
+        res = platform_type_uris_by_category(platform_cat_vocab_url=TEST_PLATFORM_CAT_VOCAB_URL)
+        self.assertEqual(res['Float'][0], 'http://vocab.nerc.ac.uk/collection/L06/current/42')
+
+    @patch("aodndata.vocab.platform_code_vocab.DEFAULT_PLATFORM_CAT_VOCAB_URL", TEST_PLATFORM_CAT_VOCAB_URL)
+    def test_altlabels_deprecated(self):
+        res = platform_altlabels_per_preflabel(category_name='Vessel', platform_vocab_url=TEST_PLATFORM_VOCAB_URL)
+        self.assertEqual(res['9VUU'], 'Anro Asia')

--- a/test_aodndata/vocab/test_xbt_line_vocab.py
+++ b/test_aodndata/vocab/test_xbt_line_vocab.py
@@ -1,0 +1,21 @@
+import os
+
+from aodncore.testlib import BaseTestCase
+from aodndata.vocab.xbt_line_vocab import XbtLineVocabHelper
+
+TEST_ROOT = os.path.join(os.path.dirname(__file__))
+
+TEST_XBT_LINE_VOCAB_URL = '%s%s' % ('file://',
+                                    os.path.join(TEST_ROOT, 'aodn_aodn-xbt-line-vocabulary.rdf'))
+
+
+class TestPlatformCodeVocab(BaseTestCase):
+    def setUp(self):
+
+        self.xbt_line_vocab_helper = XbtLineVocabHelper(TEST_XBT_LINE_VOCAB_URL)
+
+    def test_platform_type(self):
+        res = self.xbt_line_vocab_helper.xbt_line_info()
+
+        self.assertTrue('AX01' in res.keys())
+        self.assertEqual('Greenland - Iceland - Scotland', res['AX01']['xbt_line_description'])


### PR DESCRIPTION
…ave vocab URL configurable from custom_params rather than global pipeline config.

This moves the vocab module from aodncore, since it should have been located here in the first place.

@lbesnard be great if you could look over this and make sure it still works how you need to it. I fixed up all the tests and added a default URL for XBT_LINE_VOCAB_URL, but this can still be overridden on a per pipeline basis by setting the value in `custom_params`.