### PR TITLE
Query wfs urls for layer deprecated

### DIFF
--- a/aodndata/aatams/aatams_sattag.py
+++ b/aodndata/aatams/aatams_sattag.py
@@ -54,14 +54,9 @@ class AatamsSattagHandler(HandlerBase):
     def get_remote_metadata_from_zip(self, remote_pfile):
         """Fetch the metdata.csv file from a RemotePipelineFile zip and wrapping it on a
         PipelineFile."""
-        # TODO: remove the first try statement when pipeline
         remote_collection = RemotePipelineFileCollection(remote_pfile)
-        try:
-            download = self.state_query.download
-        except AttributeError:
-            download = self.state_query._storage_broker.download
 
-        download(remote_collection, self.temp_dir)
+        self.state_query.download(remote_collection, self.temp_dir)
         dest_folder = os.path.join(
             self.temp_dir, os.path.dirname(remote_pfile.dest_path)
         )

--- a/aodndata/soop/soop_trv.py
+++ b/aodndata/soop/soop_trv.py
@@ -19,16 +19,12 @@ class SoopTrvHandler(HandlerBase):
         """
         Files to be deleted as found in 'soop_trv_duplicate_url' wfs layer
         """
-        files_to_delete = self.state_query.query_wfs_urls_for_layer('soop_trv_duplicate_url')
-
-        for f in files_to_delete:
-            file_to_delete = PipelineFile(os.path.basename(f),
-                                          is_deletion=True,
-                                          dest_path=f,
-                                          file_update_callback=self._file_update_callback
-                                          )
-            file_to_delete.publish_type = PipelineFilePublishType.DELETE_UNHARVEST
-            self.file_collection.add(file_to_delete)
+        duplicate_files = self.state_query.query_wfs_files('soop_trv_duplicate_url')
+        for duplicate in duplicate_files:
+            deletion = PipelineFile.from_remotepipelinefile(duplicate,
+                                                            is_deletion=True,
+                                                            publish_type=PipelineFilePublishType.DELETE_UNHARVEST)
+            self.add_to_collection(deletion)
 
     def get_main_soop_trv_var(self, filepath):
         with Dataset(filepath, mode='r') as netcdf_file_obj:

--- a/test_aodndata/soop/test_soop_trv.py
+++ b/test_aodndata/soop/test_soop_trv.py
@@ -79,7 +79,7 @@ class TestSoopTrvHandler(HandlerTestCase):
 
         broker = WfsBroker(self.config.pipeline_config['global']['wfs_url'])
 
-        files_for_layer = broker.query_urls_for_layer('soop_trv_duplicate_url')
+        files_for_layer = broker.query_files('soop_trv_duplicate_url')
         self.assertEqual(files_for_layer[0],
                          'IMOS/SOOP/SOOP-TRV/VMQ9273_Solander/By_Cruise/Cruise_START-20181205T035932Z_END-20181206T045722Z/temperature/IMOS_SOOP-TRV_T_20181205T035932Z_VMQ9273_FV01_END-20181206T045722Z.nc')
 


### PR DESCRIPTION
Found a couple of uses of deprecated methods, which would be good to correct while doing API refactoring.