### PR TITLE
XBT NRT - QC falgs are GTSPPE (not IODE) -> not IMOS compliant anymore

### DIFF
--- a/aodndata/soop/soop_xbt_nrt.py
+++ b/aodndata/soop/soop_xbt_nrt.py
@@ -42,7 +42,6 @@ BUFR_VAR = ({
         'XBT_line': 1080,
         'ship_transect_number': 5036,
         'agency_in_charge': 1036,
-        'Height_of_XBT_launcher': 22177,
         'XBT_probetype_fallrate_equation': 22067,
         'XBT_height_launch_above_water_in_meters': 22177,
         'speed_of_motion_of_moving_observing_platform': 1013,

--- a/aodndata/templates/soop_xbt_nrt_bufr_nc_template.json
+++ b/aodndata/templates/soop_xbt_nrt_bufr_nc_template.json
@@ -57,12 +57,12 @@
       "_datatype": "b",
       "standard_name": "depth status_flag",
       "long_name": "quality flag for sea_water_temperature",
-      "quality_control_conventions": "IMOS standard flags",
+      "quality_control_conventions": "BUFR GTSPP standard flags",
       "_FillValue": 63,
       "valid_min": 0,
       "valid_max": 9,
-      "flag_values": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-      "flag_meanings": "No_QC_performed Good_data Probably_good_data Bad_data_that_are_potentially_correctable Bad_data Value_changed Not_used Not_used Not_used Missing_value"
+      "flag_values": [0, 1, 2, 3, 4, 5, 8, 9, 15],
+      "flag_meanings": "Unqualified Correct_value_all_checks_passed Probably_good_but_value_inconsistent_with_statistics_differ_from_climatology Probably_bad_spike_gradient_etc_if_other_tests_passed Bad_value_impossible_value_out_of_scale_vertical_instability_constant_profile Value_modified_during_quality_control Interpolated_value Good_for_operational_use_caution_check_literature_for_other_uses Missing_value"
     },
     "TEMP": {
       "_dimensions": ["DEPTH"],
@@ -81,20 +81,20 @@
       "_datatype": "b",
       "standard_name": "sea_water_temperature status_flag",
       "long_name": "quality flag for depth",
-      "quality_control_conventions": "IMOS standard flags",
+      "quality_control_conventions": "BUFR GTSPP standard flags",
       "_FillValue": 63,
       "valid_min": 0,
       "valid_max": 9,
-      "flag_values": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-      "flag_meanings": "No_QC_performed Good_data Probably_good_data Bad_data_that_are_potentially_correctable Bad_data Value_changed Not_used Not_used Not_used Missing_value"
+      "flag_values": [0, 1, 2, 3, 4, 5, 8, 9, 15],
+      "flag_meanings": "Unqualified Correct_value_all_checks_passed Probably_good_but_value_inconsistent_with_statistics_differ_from_climatology Probably_bad_spike_gradient_etc_if_other_tests_passed Bad_value_impossible_value_out_of_scale_vertical_instability_constant_profile Value_modified_during_quality_control Interpolated_value Good_for_operational_use_caution_check_literature_for_other_uses Missing_value"
     }
   },
-  "Conventions": "CF-1.6,IMOS-1.4",
+  "Conventions": "CF-1.6",
   "institution": "CSIRO Oceans and Atmosphere",
   "abstract": "The data are obtained from XBTs (expendable bathythermographs)",
   "source": "Expendable Bathythermograph (XBT)",
   "keywords": "Oceans>Ocean Temperature>Sea Water Temperature ;Oceans>Bathymetry/Seafloor Topography>Water Depth ;Bathythermographs>Expendable Bathythermographs (XBT)",
-  "references": "http://www.imos.org.au; 24 references                   = http://www.meds-sdmm.dfo-mpo.gc.ca/meds/Databases/OCEAN/wmocodes_e.htm; http://www.meds-sdmm.dfo-mpo.gc.ca/meds/Databases/OCEAN/GTSPPcodes_e.htm;  http://woce.nodc.noaa.gov/woce_v3/wocedata_1/woce-uot/overview.htm; https://www.nodc.noaa.gov/GTSPP/document/codetbls/gtsppcode.htm",
+  "references": "http://www.imos.org.au; 24 references = http://www.meds-sdmm.dfo-mpo.gc.ca/meds/Databases/OCEAN/wmocodes_e.htm; http://www.meds-sdmm.dfo-mpo.gc.ca/meds/Databases/OCEAN/GTSPPcodes_e.htm;  http://woce.nodc.noaa.gov/woce_v3/wocedata_1/woce-uot/overview.htm; https://www.nodc.noaa.gov/GTSPP/document/codetbls/gtsppcode.htm",
   "file_version": "Level 0 - Raw data",
   "author": "Besnard, Laurent; Cowley, Rebecca",
   "author_email": "info@aodn.org.au; rebecca.cowley@csiro.au",

--- a/test_aodndata/soop/test_soop_xbt_nrt.py
+++ b/test_aodndata/soop/test_soop_xbt_nrt.py
@@ -134,7 +134,7 @@ class TestSoopXbtNrtHandler(HandlerTestCase):
            side_effect=mock_platform_altlabels_per_preflabel)
     def test_handler(self, mock_ship):
         handler = self.run_handler(GOOD_BUFR_CSV,
-                                   check_params={'checks': ['cf', 'imos:1.4']},
+                                   check_params={'checks': ['cf']},
                                    custom_params={'xbt_line_vocab_url': TEST_XBT_LINE_VOCAB_URL})
 
         f_nc = handler.file_collection.filter_by_attribute_id('file_type', FileType.NETCDF)[0]
@@ -164,7 +164,7 @@ class TestSoopXbtNrtHandler(HandlerTestCase):
 
         # test the handler by pushing this newly created NetCDF file back into the handler
         handler = self.run_handler(nc_path,
-                                   check_params={'checks': ['cf', 'imos:1.4']},
+                                   check_params={'checks': ['cf']},
                                    custom_params={'xbt_line_vocab_url': TEST_XBT_LINE_VOCAB_URL})
         f_nc = handler.file_collection.filter_by_attribute_id('file_type', FileType.NETCDF)[0]
         self.assertEqual(f_nc.publish_type, PipelineFilePublishType.HARVEST_UPLOAD)
@@ -174,7 +174,7 @@ class TestSoopXbtNrtHandler(HandlerTestCase):
            side_effect=mock_platform_altlabels_per_preflabel)
     def test_handler_px30(self, mock_ship):
         handler = self.run_handler(GOOD_BUFR_CSV_PX30,
-                                   check_params={'checks': ['cf', 'imos:1.4']},
+                                   check_params={'checks': ['cf']},
                                    custom_params={'xbt_line_vocab_url': TEST_XBT_LINE_VOCAB_URL})
 
         f_nc = handler.file_collection.filter_by_attribute_id('file_type', FileType.NETCDF)[0]
@@ -189,7 +189,7 @@ class TestSoopXbtNrtHandler(HandlerTestCase):
            side_effect=mock_platform_altlabels_per_preflabel)
     def test_handler_noline(self, mock_ship):
         handler = self.run_handler(BUFR_CSV_NO_LINE,
-                                   check_params={'checks': ['cf', 'imos:1.4']},
+                                   check_params={'checks': ['cf']},
                                    custom_params={'xbt_line_vocab_url': TEST_XBT_LINE_VOCAB_URL})
 
         f_nc = handler.file_collection.filter_by_attribute_id('file_type', FileType.NETCDF)[0]


### PR DESCRIPTION
NetCDF files were created with IODE flags. Bec Cowley noticed that the flags were actually GTSPPE flags. These flags aren't part of the IMOS convention, so the NetCDF file aren't compliant anymore. This needs to be reflected in the chef-private databags