### PR TITLE
Update GitHub Actions to test against python 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.5', '3.6' ]
+        python-version: [ '3.5', '3.8' ]
         stage: [ 'build', 'rc', 'production']
     steps:
     - uses: actions/checkout@v2

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,5 +1,5 @@
 cftime<1.1.1;python_version=='3.5'
-cftime<1.5;python_version=='3.8'
+cftime<1.5
 pandas<0.25.0;python_version=='3.5'
 xarray<0.14.0;python_version=='3.5'
 netCDF4<1.5.4;python_version=='3.5'

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,4 +1,5 @@
 cftime<1.1.1;python_version=='3.5'
+cftime<1.5;python_version=='3.8'
 pandas<0.25.0;python_version=='3.5'
 xarray<0.14.0;python_version=='3.5'
 netCDF4<1.5.4;python_version=='3.5'


### PR DESCRIPTION
Update the GitHub Actions config to test against the most relevant versions of python, in line with python-aodncore.