### PR TITLE
Add conda stage_environmnent.yml file for PO dev

### DIFF
--- a/stage_environment.yml
+++ b/stage_environment.yml
@@ -1,0 +1,28 @@
+# An environment file for Project Officers wanted to use Conda rather than
+# virtualenv
+# This is based on scripts/setup_virtualenv.sh and doesn't interfere with the
+# wheel package
+# STAGE values {rc, build, production}
+# Usage:
+# export STAGE=build && conda env create --file=stage_environment.yml
+# export STAGE=build && conda env update --file=stage_environment.yml
+
+name: python-aodndata-conda
+channels:
+  - conda-forge
+  - defaults
+  - pypi
+dependencies:
+  - cython
+  - cf-units  # force cf-units to be installed from conda-forge. packaged failed otherwise
+  - python=3.8
+  - pip
+  - pip:
+    - numpy<1.19.0
+    - --index-url http://imos-artifacts.s3-website-ap-southeast-2.amazonaws.com/repo/pypi/${STAGE}/
+    - --extra-index-url https://pypi.python.org/simple/
+    - --trusted-host imos-artifacts.s3-website-ap-southeast-2.amazonaws.com
+    - pytest-cov
+    - -c file:constraints.txt
+    - -e .
+    - -e .[testing]


### PR DESCRIPTION
A conda environment file to simply deploy a working virtual environment. This is based on https://github.com/aodn/python-aodndata/blob/master/scripts/setup_virtualenv.sh

I have had issues with the original script with new version of ubuntu/mint. The old setup_virtualenv.sh script is using the system python to create a virtualenv. On the other end, this conda environment file doesn't rely on this. I would be happy to modify the README of this repo to add an alternative way to PO (like me), who have had issues with the virtualenv script, to setup a working python virtual env.

This doesn't need to be packaged in the wheel, and doesn't affect the repo apart from having a new file. I'm not too fussed if this is not added but I think it would be valuable.

FYI @ana-berger @mhidas @bpasquer @leonardolaiolo 
