### PR TITLE
Don't pin numpy version in github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install "numpy<1.19.0"
+        pip install numpy
         pip install -r stage_requirements.txt
         pip install pytest-cov
       env:


### PR DESCRIPTION
This should allow unittests to run successfully in both Python 3.5 and 3.8 (see https://github.com/aodn/python-aodncore/pull/235)