### PR TITLE
(BugFix) New pip version 21.2.1 breaks conda env

### DIFF
--- a/stage_environment.yml
+++ b/stage_environment.yml
@@ -18,11 +18,11 @@ dependencies:
   - python=3.8
   - pip
   - pip:
-    - numpy<1.19.0
+    - numpy>1.19.0
     - --index-url http://imos-artifacts.s3-website-ap-southeast-2.amazonaws.com/repo/pypi/${STAGE}/
     - --extra-index-url https://pypi.python.org/simple/
     - --trusted-host imos-artifacts.s3-website-ap-southeast-2.amazonaws.com
     - pytest-cov
-    - -c file:constraints.txt
+    - -c constraints.txt
     - -e .
     - -e .[testing]


### PR DESCRIPTION
see for ref https://stackoverflow.com/questions/68571543/using-a-pip-requirements-file-in-a-conda-yml-file-throws-attributeerror-fileno
