### PR TITLE
Turn off fail-fast in github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
       matrix:
         python-version: [ '3.5', '3.8' ]
         stage: [ 'build', 'rc', 'production']
+      fail-fast: false
     steps:
     - uses: actions/checkout@v2
     - name: Install libudunits2-dev


### PR DESCRIPTION
This should allow all jobs in the matrix to run to the end (i.e., even when some fail) to give us more complete information.