### PR TITLE
feat: allow hourly-depth-gridded-product in MooringsFileClassifier

### DIFF
--- a/aodndata/moorings/classifiers.py
+++ b/aodndata/moorings/classifiers.py
@@ -307,7 +307,7 @@ class DwmFileClassifier(MooringsFileClassifier):
 
         fac, subfac = cls._get_facility(input_file)
         is_asfs_and_rt = subfac == 'ASFS' and cls._is_realtime(input_file)
-        if 'FV02_daily-depth-gridded-product' in input_file_basename:
+        if re.match('^.+FV02_(daily|hourly)-depth-gridded-product', input_file_basename):
             dir_list.append(subfac)
             dir_list.append('CSIRO_gridded_all_variables')
         elif subfac == 'DA':

--- a/test_aodndata/moorings/test_dwmFileClassifier.py
+++ b/test_aodndata/moorings/test_dwmFileClassifier.py
@@ -320,5 +320,13 @@ class TestDwmFileClassifier(BaseTestCase):
         self.assertEqual(dest_dir, 'IMOS/DWM/DA/CSIRO_gridded_all_variables')
         self.assertEqual(dest_filename, filename)
 
+    def test_hourly_depth_gridded_product(self):
+        filename = 'IMOS_DWM-DA_STZV_20120401_EAC2000_FV02_hourly-depth-gridded-product_END-20190924_C-20210910.nc'
+        testfile = os.path.join(self.tempdir, filename)
+        make_test_file(testfile, {'site_code': 'EAC2000', 'featureType': 'timeSeriesProfile'}, TIME={}, DEPTH={}, TEMP={}, PSAL={}, UCUR={}, VCUR={})
+        dest_dir, dest_filename = os.path.split(DwmFileClassifier.dest_path(testfile))
+        self.assertEqual(dest_dir, 'IMOS/DWM/DA/CSIRO_gridded_all_variables')
+        self.assertEqual(dest_filename, filename)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
updated DWM classifier to also work for "hourly-depth-gridded-product": https://github.com/aodn/PO-Backlog/issues/2589