### PR TITLE
Updating mooring pipeline to ingest NTP profiling mooring files

### DIFF
--- a/aodndata/moorings/classifiers.py
+++ b/aodndata/moorings/classifiers.py
@@ -121,8 +121,10 @@ class MooringsFileClassifier(FileClassifier):
 
         dir_list = [cls.PROJECT]
         dir_list.extend(cls._get_facility(input_file))
-
-        if input_file.endswith('.nc'):
+        if name_fields[1] == 'NTP-PME':
+            dir_list[2] = 'Profiling_Moorings'
+            dir_list.append(cls._get_site_code(input_file))
+        elif input_file.endswith('.nc'):
             dir_list.append(cls._get_site_code(input_file))
             dir_list.append(cls._get_data_category(input_file))
             dir_list.append(cls._get_product_level(input_file))

--- a/test_aodndata/moorings/test_mooringsFileClassifier.py
+++ b/test_aodndata/moorings/test_mooringsFileClassifier.py
@@ -354,6 +354,21 @@ class TestMooringFileClassifier(BaseTestCase):
         make_test_file(testfile, {'site_code': 'NRSMAI'}, xCO2EQ_PPM={})
         self.assertRaises(InvalidFileNameError, MooringsFileClassifier.dest_path, testfile)
 
+    def test_profiling_mooring(self):
+        filename = 'IMOS_NTP-PME_BCFPST_20200308_GBRPPS-WireWalker_FV00_GBRPPS-WireWalker-01-2020-RBRmaestro3-200699-30m_END-20200417_C-20210917.nc'
+        testfile = os.path.join(self.tempdir, filename)
+        make_test_file(testfile,
+                       {'site_code': 'GBRPPS',
+                        'featureType': 'timeSeries'},
+                       TEMP={},
+                       CPHL={},
+                       PSAL={}
+                       )
+        dest_dir, dest_filename = os.path.split(MooringsFileClassifier.dest_path(testfile))
+        self.assertEqual(dest_dir, 'IMOS/NTP/Profiling_Moorings/GBRPPS')
+        self.assertEqual(dest_filename, filename)
+
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
@mhidas I believe the check fails are related to the issues that you are already fixing for mooring products? Here is the error I get in my local machine when I run the `test_mooringsProductsHandler.py`:
> FAILED [ 41%]
test_aodndata/moorings/test_mooringsProductsHandler.py:130 (TestMooringsProductsHandler.test_velocity_hourly)
self = <test_aodndata.moorings.test_mooringsProductsHandler.TestMooringsProductsHandler testMethod=test_velocity_hourly>
