### PR TITLE
fix aodndata module version entry point for aodncore

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ ENTRY_POINTS = {
         'dest_path_srs_surface_waves_sar = aodndata.srs.srs_surface_waves:dest_path_srs_surface_waves_sar'
     ],
     'pipeline.module_versions': [
-        'aodndata = aodndata.version:__version__',
+        'aodndata = aodndata:__version__',
         'cc-plugin-imos = cc_plugin_imos:__version__',
         'aodntools = aodntools:__version__'
     ]


### PR DESCRIPTION
Another version import change that was missed in previous PRs.
This one is needed so that the pipelines can report all the current package versions in their log. E.g.
```
... running handler -> MooringsHandler({'versions': {'python': '3.8.13', 'aodncore': '1.3.11', 'aodndata': '1.3.87', '
aodntools': '1.5.3', 'cc-plugin-imos': '1.4.11', 'compliance-checker': '4.1.1'}, ... )
```
Currently it is saying `'aodndata': 'LOAD_FAILED'`