### PR TITLE
Constrain numpy version to fix unittests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,9 +45,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pytest-runner
-        pip install numpy
         pip install pyshp
-        #pip install shapely --no-binary shapely
         pip install scipy
         pip install -r stage_requirements.txt
         pip install pytest-cov

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,10 +1,5 @@
-cftime<1.1.1;python_version=='3.5'
 cftime<1.5
-pandas<0.25.0;python_version=='3.5'
-xarray<0.14.0;python_version=='3.5'
-netCDF4<1.5.4;python_version=='3.5'
 chardet<4  # temporarily pin to dependency conflict until requests library removes their <4 constraint
-testfixtures<=6.18.3';python_version=='3.5' # >6.18.3 not working under python 3.5.10
 
 # Current versions of compliance-checker (5.0.1) and cc-plugin-imos (1.5.3) both use deprecated types
 # numpy.float / numpy.int which have been removed in numpy 1.24

--- a/constraints.txt
+++ b/constraints.txt
@@ -5,3 +5,7 @@ xarray<0.14.0;python_version=='3.5'
 netCDF4<1.5.4;python_version=='3.5'
 chardet<4  # temporarily pin to dependency conflict until requests library removes their <4 constraint
 testfixtures<=6.18.3';python_version=='3.5' # >6.18.3 not working under python 3.5.10
+
+# Current versions of compliance-checker (5.0.1) and cc-plugin-imos (1.5.3) both use deprecated types
+# numpy.float / numpy.int which have been removed in numpy 1.24
+numpy<1.24.0

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
     author_email='developers@emii.org.au',
     description='AODN pipeline library',
     zip_safe=False,
-    python_requires='>=3.5',
+    python_requires='>=3.8',
     install_requires=INSTALL_REQUIRES,
     extras_require=EXTRAS_REQUIRE,
     tests_require=TESTS_REQUIRE,
@@ -116,8 +116,7 @@ setup(
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: CPython',
     ],
 )


### PR DESCRIPTION
Numpy version 1.24 has removed types `numpy.int` and `numpy.float`, which are referenced in current versions of the compliance-checker (and our plugin). We need to avoid this version of numpy until those packages have been updated accordingly.
Same issue as https://github.com/aodn/python-aodncore/pull/272