### PR TITLE
moorings_product_trigger fixup: process all sites

### DIFF
--- a/aodndata/moorings/moorings_product_trigger.py
+++ b/aodndata/moorings/moorings_product_trigger.py
@@ -45,6 +45,8 @@ def get_files_dataframe(filters: list = None,
     gf_kwargs.update(propertyname=propertyname, outputFormat='csv')
     if filters:
         gf_kwargs['filter'] = etree.tostring(And(filters).toXML(), encoding='unicode')
+    if read_csv_kwargs is None:
+        read_csv_kwargs = dict()
 
     with WFS_BROKER.wfs.getfeature(typename=INDEX_LAYER, **gf_kwargs) as response:
         df = pd.read_csv(response, **read_csv_kwargs)
@@ -185,7 +187,7 @@ if __name__ == "__main__":
 
     site_codes = args.site_code
     all_files = all_files_df()
-    if hasattr(args, 'sub_facility'):
+    if args.sub_facility is not None:
         idx = all_files.url.map(lambda s: s.startswith(f"IMOS/ANMN/{args.sub_facility}/"))
         all_files = all_files.loc[idx]
     if len(site_codes) == 0:


### PR DESCRIPTION
This is just a small fix to allow the `moorings_product_trigger.py` script to process all sites by default (when no sub-facility or sites are specified on the command-line).