### PR TITLE
Publish SOTS gridded multiyear data in new sub-directory

### DIFF
--- a/aodndata/moorings/classifiers.py
+++ b/aodndata/moorings/classifiers.py
@@ -326,13 +326,18 @@ class DwmFileClassifier(MooringsFileClassifier):
             dir_list += ['ASFS', 'SOFS', cat, 'Real-time', rt_folder_name]
         elif subfac in ('SOTS', 'ASFS'):
             dir_list.append('SOTS')
-            # Check for data_product_type attribute
-            if cls._get_nc_att(input_file, 'data_product_type'):
-                dir_list.append('derived_products')
-            else:
-                dir_list.append(cls._get_deployment_year(input_file))
-                if cls._is_realtime(input_file):
-                    dir_list.append('real-time')
+            # Open the NetCDF file
+            dataset = cls._open_nc_file(input_file)
+            try:
+                # Check for data_product_type attribute
+                if hasattr(dataset, 'data_product_type'):
+                    dir_list.append('derived_products')
+                else:
+                    dir_list.append(cls._get_deployment_year(input_file))
+                    if cls._is_realtime(input_file):
+                        dir_list.append('real-time')
+            finally:
+                dataset.close()
         else:
             raise InvalidFileNameError(
                 "Unknown DWM sub-facility '{subfac}' for file '{input_file}'".format(subfac=subfac,

--- a/aodndata/moorings/classifiers.py
+++ b/aodndata/moorings/classifiers.py
@@ -279,6 +279,8 @@ class DwmFileClassifier(MooringsFileClassifier):
           'IMOS/DWM/SOTS/calibration'
           or
           'IMOS/DWM/SOTS/images'
+          or
+          'IMOS/DWM/SOTS/derived_products'
 
         where
         <platform_code> is the value of the platform_code global attribute
@@ -324,9 +326,13 @@ class DwmFileClassifier(MooringsFileClassifier):
             dir_list += ['ASFS', 'SOFS', cat, 'Real-time', rt_folder_name]
         elif subfac in ('SOTS', 'ASFS'):
             dir_list.append('SOTS')
-            dir_list.append(cls._get_deployment_year(input_file))
-            if cls._is_realtime(input_file):
-                dir_list.append('real-time')
+            # Check for data_product_type attribute
+            if cls._get_nc_att(input_file, 'data_product_type'):
+                dir_list.append('derived_products')
+            else:
+                dir_list.append(cls._get_deployment_year(input_file))
+                if cls._is_realtime(input_file):
+                    dir_list.append('real-time')
         else:
             raise InvalidFileNameError(
                 "Unknown DWM sub-facility '{subfac}' for file '{input_file}'".format(subfac=subfac,

--- a/aodndata/moorings/classifiers.py
+++ b/aodndata/moorings/classifiers.py
@@ -326,18 +326,17 @@ class DwmFileClassifier(MooringsFileClassifier):
             dir_list += ['ASFS', 'SOFS', cat, 'Real-time', rt_folder_name]
         elif subfac in ('SOTS', 'ASFS'):
             dir_list.append('SOTS')
-            # Open the NetCDF file
-            dataset = cls._open_nc_file(input_file)
-            try:
-                # Check for data_product_type attribute
-                if hasattr(dataset, 'data_product_type'):
-                    dir_list.append('derived_products')
+            data_product_type = cls._get_nc_att(input_file, 'data_product_type', default=False)
+            if data_product_type:
+                dir_list.append('derived_products')
+                if data_product_type == 'gridded_data':
+                    dir_list.append('gridded')
                 else:
-                    dir_list.append(cls._get_deployment_year(input_file))
-                    if cls._is_realtime(input_file):
-                        dir_list.append('real-time')
-            finally:
-                dataset.close()
+                    dir_list.append(data_product_type)
+            else:
+                dir_list.append(cls._get_deployment_year(input_file))
+                if cls._is_realtime(input_file):
+                    dir_list.append('real-time')
         else:
             raise InvalidFileNameError(
                 "Unknown DWM sub-facility '{subfac}' for file '{input_file}'".format(subfac=subfac,

--- a/test_aodndata/moorings/test_dwmFileClassifier.py
+++ b/test_aodndata/moorings/test_dwmFileClassifier.py
@@ -328,5 +328,19 @@ class TestDwmFileClassifier(BaseTestCase):
         self.assertEqual(dest_dir, 'IMOS/DWM/DA/CSIRO_gridded_all_variables')
         self.assertEqual(dest_filename, filename)
 
+    def test_sots_derived_product(self):
+        filename = 'IMOS_DWM-SOTS_BCOPSTUW_20210420_SOFS_FV02_SOFS-10-2021-hourly-gridded-product_END-20220512_C-20221117.nc'
+        testfile = os.path.join(self.tempdir, filename)
+        make_test_file(testfile, {
+            'site_code': 'SOTS',
+            'platform_code': 'SOFS',
+            'data_product_type': 'derived'
+        })
+        dest_dir, dest_filename = os.path.split(DwmFileClassifier.dest_path(testfile))
+        expected_dir = 'IMOS/DWM/SOTS/derived_products'
+        self.assertEqual(dest_dir, expected_dir)
+        self.assertEqual(dest_filename, filename)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test_aodndata/moorings/test_dwmFileClassifier.py
+++ b/test_aodndata/moorings/test_dwmFileClassifier.py
@@ -328,16 +328,16 @@ class TestDwmFileClassifier(BaseTestCase):
         self.assertEqual(dest_dir, 'IMOS/DWM/DA/CSIRO_gridded_all_variables')
         self.assertEqual(dest_filename, filename)
 
-    def test_sots_derived_product(self):
+    def test_sots_derived_product_gridded(self):
         filename = 'IMOS_DWM-SOTS_BCOPSTUW_20210420_SOFS_FV02_SOFS-10-2021-hourly-gridded-product_END-20220512_C-20221117.nc'
         testfile = os.path.join(self.tempdir, filename)
         make_test_file(testfile, {
             'site_code': 'SOTS',
             'platform_code': 'SOFS',
-            'data_product_type': 'derived'
+            'data_product_type': 'gridded_data'
         })
         dest_dir, dest_filename = os.path.split(DwmFileClassifier.dest_path(testfile))
-        expected_dir = 'IMOS/DWM/SOTS/derived_products'
+        expected_dir = 'IMOS/DWM/SOTS/derived_products/gridded'
         self.assertEqual(dest_dir, expected_dir)
         self.assertEqual(dest_filename, filename)
 


### PR DESCRIPTION
@mhidas 
I could not use `_get_nc_att` because it was failing some unittest. Indeed, it was raising an `InvalidFileContentError` (you can have a look at my first attempt in commit 435d59c) for the files that do not have 'data_product_type' as attribute. I then avoid using '_get_nc_att' and used instead `_open_nc_file` and `hasattr` to avoid the `InvalidFileContentError` (commit ade1b3f)