### PR TITLE
lock pip version to use the required click module version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip==24.0
         pip install pytest-runner
         pip install pyshp
         pip install scipy


### PR DESCRIPTION
https://github.com/aodn/issues/issues/1498