### PR TITLE
Edited to skip creating products specified in the skip_sites.json

### DIFF
--- a/aodndata/moorings/moorings_product_trigger.py
+++ b/aodndata/moorings/moorings_product_trigger.py
@@ -18,6 +18,10 @@ import pandas as pd
 from aodncore.pipeline.config import CONFIG
 from aodncore.util import wfs
 
+# import config json
+with open("aodndata/moorings/skip_sites.json", "r") as f:
+    SKIP_SITES = json.load(f)
+
 # Variables included in the products
 INCLUDED_VARIABLES = {'TEMP', 'PSAL', 'CPHL', 'CHLF', 'CHLU', 'TURB', 'DOX1', 'DOX2', 'DOXS', 'PAR', 'VCUR'}
 
@@ -162,6 +166,16 @@ def make_manifest(all_files: pd.DataFrame, site_code: str) -> dict:
                 'variables': list(new_vars),
                 'products': list(products)
                 }
+    
+    # skip products for sites listed in the skip_sites.json file
+    if site_code in SKIP_SITES:
+        products_to_skip = SKIP_SITES[site_code]
+        for product in products_to_skip:
+            if product in manifest["products"]:
+                manifest["products"].remove(product)
+        print(f"{site_code}  |  Skipping the following product/s:")
+        print(f"{site_code}  |  {', '.join(products_to_skip)}")
+    
     return manifest
 
 

--- a/aodndata/moorings/skip_sites.json
+++ b/aodndata/moorings/skip_sites.json
@@ -1,0 +1,23 @@
+{
+    "NRSDAR": ["gridded"],
+    "NRSMAI": ["gridded"],
+    "NRSNSI": ["gridded"],
+    "NRSYON": ["gridded","hourly"],
+    "DARBGF": ["gridded"],
+    "WATR04": ["gridded"],
+    "PAPCA":  ["gridded"],
+    "PAPOR":  ["gridded"],
+    "PATUN":  ["gridded"],
+    "SAM1DS": ["gridded"],
+    "SAM2CP": ["gridded"],
+    "SAM3MS": ["gridded"],
+    "SAM4CY": ["gridded"],
+    "SAM5CB": ["gridded"],
+    "SAM6IS": ["gridded"],
+    "SAM7DS": ["gridded"],
+    "SAM8SG": ["gridded"],
+    "SAMUSG": ["gridded"],
+    "SR030":  ["gridded"],
+    "SR050":  ["gridded"]
+}
+  


### PR DESCRIPTION
I have created a `skip_sites.json` file that lists mooring sites along with the products that we want to skip. That json file is imported into `aodndata/moorings/moorings_product_trigger.py` and used to update manifest to skip products at listed sites. 