### PR TITLE
Fix-unittests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,9 @@ jobs:
         pip install scipy
         pip install -r stage_requirements.txt
         pip install pytest-cov
+        pip install click==7.1.2
+        pip install celery==5.1.2
+        pip install fiona==1.8.18
       env:
         STAGE: ${{ matrix.stage }}
     - name: Test with pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,17 +45,19 @@ jobs:
       run: |
         python -m pip install --upgrade pip==24.0
 
+        # patch to solve dependency issues with celery / fiona / click
+        # download troublesome celery package 
         wget https://files.pythonhosted.org/packages/source/c/celery/celery-5.1.2.tar.gz
         tar -xzf celery-5.1.2.tar.gz
         cd celery-5.1.2
-
+        # patch the requirements to use pytz>=2020.1 instead of known bug pytz>dev
         sed -i "s/pytz>dev/pytz>=2020.1/g" requirements/default.txt
         sed -i "s/pytz>dev/pytz>=2020.1/g" celery.egg-info/requires.txt
         sed -i "s/pytz>dev/pytz>=2020.1/g" requirements/dev.txt
-
+        # install the package
         python setup.py install
         cd ..
-
+        # remove downlaoded copy of celery
         rm -rf celery-5.1.2 celery-5.1.2.tar.gz
 
         pip install pytest-runner
@@ -63,7 +65,7 @@ jobs:
         pip install scipy
         pip install -r stage_requirements.txt
         pip install pytest-cov
-        pip list
+
       env:
         STAGE: ${{ matrix.stage }}
     - name: Test with pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,10 +49,7 @@ jobs:
         pip install scipy
         pip install -r stage_requirements.txt
         pip install pytest-cov
-        aodncore==1.4.12
-        pip install click==7.1.2
         pip install celery==5.4.0
-        pip install fiona==1.8.18
         pip list
       env:
         STAGE: ${{ matrix.stage }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
         pip install scipy
         pip install -r stage_requirements.txt
         pip install pytest-cov
-        pip install fiona==1.10.1
+        pip install fiona>=1.8.8,<1.8.19
         pip install click==8.1.8
         pip install celery==5.4.0
         pip list

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
         pip install pytest-cov
         aodncore==1.4.12
         pip install click==7.1.2
-        pip install celery==5.1.2
+        pip install celery==5.4.0
         pip install fiona==1.8.18
         pip list
       env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,14 +45,13 @@ jobs:
       run: |
         python -m pip install --upgrade pip==24.0
 
-        pip download celery==5.1.2 --no-binary :all:
+        wget https://files.pythonhosted.org/packages/source/c/celery/celery-5.1.2.tar.gz
         tar -xzf celery-5.1.2.tar.gz
         cd celery-5.1.2
 
         sed -i "s/'pytz>dev'/'pytz>=2020.1'/" setup.py
 
-        python setup.py bdist_wheel
-        pip install dist/celery-5.1.2-*.whl
+        python setup.py install
         cd ..
 
         pip install pytest-runner

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,8 @@ jobs:
         pip install -r stage_requirements.txt
         pip install pytest-cov
         pip install fiona==1.10.1
+        pip install click==8.1.8
+        pip install celery==5.4.0
         pip list
       env:
         STAGE: ${{ matrix.stage }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,9 +49,11 @@ jobs:
         pip install scipy
         pip install -r stage_requirements.txt
         pip install pytest-cov
+        aodncore==1.4.12
         pip install click==7.1.2
         pip install celery==5.1.2
         pip install fiona==1.8.18
+        pip list
       env:
         STAGE: ${{ matrix.stage }}
     - name: Test with pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,12 +45,12 @@ jobs:
       run: |
         python -m pip install --upgrade pip==24.0
 
-        # patch to solve dependency issues with celery / fiona / click
-        # download troublesome celery package 
+        # patch to solve dependency issues with celery / fiona / click / pytz
+        # download celery package 
         wget https://files.pythonhosted.org/packages/source/c/celery/celery-5.1.2.tar.gz
         tar -xzf celery-5.1.2.tar.gz
         cd celery-5.1.2
-        # patch the requirements to use pytz>=2020.1 instead of known bug pytz>dev
+        # patch the requirements to use pytz>=2020.1 instead of pytz>dev which causes issues
         sed -i "s/pytz>dev/pytz>=2020.1/g" requirements/default.txt
         sed -i "s/pytz>dev/pytz>=2020.1/g" celery.egg-info/requires.txt
         sed -i "s/pytz>dev/pytz>=2020.1/g" requirements/dev.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,9 @@ jobs:
         tar -xzf celery-5.1.2.tar.gz
         cd celery-5.1.2
 
-        sed -i "s/'pytz>dev'/'pytz>=2020.1'/" setup.py
+        sed -i "s/pytz>dev/pytz>=2020.1/g" requirements/default.txt
+        sed -i "s/pytz>dev/pytz>=2020.1/g" celery.egg-info/requires.txt
+        sed -i "s/pytz>dev/pytz>=2020.1/g" requirements/dev.txt
 
         python setup.py install
         cd ..

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
         python setup.py install
         cd ..
 
-        rm -rf celery-5.1.2
+        rm -rf celery-5.1.2 celery-5.1.2.tar.gz
 
         pip install pytest-runner
         pip install pyshp

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,8 @@ jobs:
         python setup.py install
         cd ..
 
+        rm -rf celery-5.1.2
+
         pip install pytest-runner
         pip install pyshp
         pip install scipy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
         pip install scipy
         pip install -r stage_requirements.txt
         pip install pytest-cov
-        pip install celery==5.4.0
+        pip install fiona==1.10.1
         pip list
       env:
         STAGE: ${{ matrix.stage }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,14 +44,22 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip==24.0
+
+        pip download celery==5.1.2 --no-binary :all:
+        tar -xzf celery-5.1.2.tar.gz
+        cd celery-5.1.2
+
+        sed -i "s/'pytz>dev'/'pytz>=2020.1'/" setup.py
+
+        python setup.py bdist_wheel
+        pip install dist/celery-5.1.2-*.whl
+        cd ..
+
         pip install pytest-runner
         pip install pyshp
         pip install scipy
         pip install -r stage_requirements.txt
         pip install pytest-cov
-        pip install fiona>=1.8.8,<1.8.19
-        pip install click==8.1.8
-        pip install celery==5.4.0
         pip list
       env:
         STAGE: ${{ matrix.stage }}

--- a/constraints.txt
+++ b/constraints.txt
@@ -8,7 +8,3 @@ numpy<1.24.0
 # Limit pandas version until we update our code for the changes in v2.0
 # see https://pandas.pydata.org/docs/whatsnew/v2.0.0.html#backwards-incompatible-api-changes
 pandas<2.0
-
-click==7.1.2
-celery==5.1.2
-fiona==1.8.18

--- a/constraints.txt
+++ b/constraints.txt
@@ -8,3 +8,7 @@ numpy<1.24.0
 # Limit pandas version until we update our code for the changes in v2.0
 # see https://pandas.pydata.org/docs/whatsnew/v2.0.0.html#backwards-incompatible-api-changes
 pandas<2.0
+
+click==7.1.2
+celery==5.1.2
+fiona==1.8.18


### PR DESCRIPTION
We have had issues with the unit tests failing for the following PRs:
- https://github.com/aodn/PO-Backlog/issues/3980
- https://github.com/aodn/PO-Backlog/issues/3935
- https://github.com/aodn/backlog/issues/6473

**Error**

The error ([see issue here](https://github.com/aodn/issues/issues/1544)) was due to the `pytz>dev` requirement that `celery==5.1.2` had, which is a [known issue](https://github.com/celery/celery/discussions/9112).

**Cause**
It is a known bug in `celery==5.1.2` that it incorrectly specifies the invalid requirement `pytz>dev`. This is allowed when using `pip==24.0` (as in our case), but if we upgraded pip it would fail.

We can't upgrade celery, because we require `fiona==1.8.18` (as per this requirement `fiona>=1.8.8,<1.8.19` in aodncore) that requires `click<=7.1.2`. Upgrading celery to include the fix requires `click>=8.1.8`...

ChatGPT said it best: "You’re in a tough corner of dependency hell"

**Solution**

During the Github Action 'Install dependencies' step, the celery package is downloaded, the requirements files are edited to use `pytz>=2020.1`, and then the package is installed. This bit removes the `pytz>dev` dependency that was causing trouble.  This seemed to be the only option as upgrading celery would cause conflicts with the other packages. 