### PR TITLE
atacoustic unittest to match new schema check

### DIFF
--- a/test_aodndata/aatams/IMOS_ATF-ACOUSTIC.schema.yaml
+++ b/test_aodndata/aatams/IMOS_ATF-ACOUSTIC.schema.yaml
@@ -97,7 +97,6 @@ fields:
     constraints: {'required': True}
   - type: string
     name: transmitter_serial_number
-    constraints: {'required': True}
   - type: integer
     name: transmitter_estimated_battery_life
   - type: string


### PR DESCRIPTION
updating the yaml for the schema check in the unittest as the schema check has been relaxed in public schema for `transmitter_serial_number`

Link to ticket: https://github.com/aodn/backlog/issues/6878